### PR TITLE
docs: clarify core configStore usage

### DIFF
--- a/packages/core.md
+++ b/packages/core.md
@@ -32,7 +32,7 @@ if (isDev()) {
 ```typescript
 import { createConfig, defineConfig, Environment } from '@bunary/core';
 
-export const config = createConfig(
+export const configStore = createConfig(
   defineConfig({
     app: {
       name: 'My API',
@@ -41,6 +41,9 @@ export const config = createConfig(
     },
   }),
 );
+
+// The resolved config object (use this in most app code)
+export default configStore.get();
 ```
 
 ## API Reference


### PR DESCRIPTION
## Summary
- Rename the `createConfig(...)` example export to `configStore` to avoid confusion between the store and the resolved config.
- Add an explicit `configStore.get()` example line.

## Test plan
- N/A (documentation only)

Closes #5