### PR TITLE
chore: prevent package docs sync drift

### DIFF
--- a/.github/workflows/docs-sync-drift.yml
+++ b/.github/workflows/docs-sync-drift.yml
@@ -1,0 +1,33 @@
+name: Docs sync drift check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync_drift:
+    name: Verify synced package docs are up to date
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Run docs sync
+        run: bun run sync:packages
+
+      - name: Fail on drift
+        shell: bash
+        run: |
+          if ! git diff --quiet -- packages; then
+            echo "::error::Synced package docs are out of date. Run 'bun run sync:packages' and commit the changes."
+            git --no-pager diff -- packages
+            exit 1
+          fi
+

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ This will update:
 - `packages/orm.md`
 - `packages/cli.md`
 
+### CI drift check
+
+Pull requests are expected to keep `packages/*.md` in sync. CI will fail if `bun run sync:packages` produces changes that are not committed.
+
 ## Writing Documentation
 
 ### Guides


### PR DESCRIPTION
## Summary
- Adds a CI workflow that runs `bun run sync:packages` and fails if it produces an uncommitted diff in `packages/*.md`.
- Adds a short note to the README so contributors know how to fix failures.

Closes #9