### PR TITLE
docs: audit package docs for drift (post-feature work)

### DIFF
--- a/guides/basics/index.md
+++ b/guides/basics/index.md
@@ -45,7 +45,7 @@ app.use(cors);
 
 app.get("/", () => ({ message: "Hello!" }));
 
-app.listen(3000);
+app.listen({ port: 3000 });
 ```
 
 ## Middleware Order

--- a/guides/getting-started/index.md
+++ b/guides/getting-started/index.md
@@ -84,7 +84,7 @@ app.get("/health", () => ({
   timestamp: new Date().toISOString(),
 }));
 
-const server = app.listen(3000);
+const server = app.listen({ port: 3000 });
 console.log(`🚀 Server running at http://localhost:${server.port}`);
 ```
 

--- a/guides/routing/index.md
+++ b/guides/routing/index.md
@@ -15,7 +15,7 @@ app.get("/", () => {
   return { message: "Hello, World!" };
 });
 
-app.listen(3000);
+app.listen({ port: 3000 });
 ```
 
 ## Available HTTP Methods
@@ -85,6 +85,7 @@ Every route handler receives a `RequestContext` object with the following proper
 | `request` | Request | The native Fetch API Request object |
 | `params` | Record<string, string> | URL route parameters |
 | `query` | URLSearchParams | Query string parameters |
+| `locals` | Record<string, unknown> | Per-request data (e.g. `ctx.locals.auth` from auth middleware) |
 
 ## Accessing Request Data
 


### PR DESCRIPTION
**Issue #24:** Audit package docs for drift; update guides and other docs as needed.

**Done:**
1. Ran `bun run sync:packages` — `packages/*.md` were already in sync with package repos (no changes).
2. Audited guides against package APIs and updated:
   - **app.listen:** Standardized to `app.listen({ port: 3000 })` in getting-started, routing, and basics (matches @bunary/http).
   - **Auth:** Security index and guards now use app-scoped auth (`createAuth()`, `createJwtGuard()`, `createBasicGuard()`, `ctx.locals.auth`) instead of global `createAuthManager` / `authManager.authenticate()` (matches @bunary/auth).
   - **RequestContext:** Added `locals` to the context table in the routing guide (for `ctx.locals.auth` etc.).

Package doc source of truth remains in each package repo; this PR only updates guides in this repo.

Closes #24