### PR TITLE
feat: keep build/sync scripts in documentation repo (sync:packages, sync:site, sync)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -52,23 +52,19 @@ documentation/
 
 ## Building Documentation
 
-The documentation is built from markdown files into React components for the site.
+All build/sync scripts live in this repo and are run from the documentation repo root (e.g. `cd documentation && bun run …`).
 
-Run the build script:
-```bash
-bun run scripts/build-docs.ts
-```
+### Commands
 
-This will:
-1. Read markdown files from `documentation/guides/` and `documentation/packages/`
-2. Convert them to React components using the `marked` library
-3. Output to `site/src/pages/docs/`
+| Command | What it does |
+|--------|----------------|
+| `bun run sync:packages` | Fetch package `docs/index.md` from GitHub and write `packages/*.md` in this repo. |
+| `bun run sync:site` | Build guides + packages markdown into React components for the site. Cleans the site docs output dir, then generates. |
+| `bun run sync` | Run `sync:packages` then `sync:site` (full pipeline). |
 
-## Syncing package docs (pkg/docs → documentation/packages)
+### sync:packages
 
 Package documentation is authored in each package repo under `docs/` and synced into this repo under `packages/`.
-
-Run:
 
 ```bash
 bun run sync:packages
@@ -86,6 +82,21 @@ This will update:
 Pull requests are expected to keep `packages/*.md` in sync. CI will fail if `bun run sync:packages` produces changes that are not committed.
 
 Review checklist (contract, per-package alignment, guides): [DOCS_REVIEW.md](./DOCS_REVIEW.md).
+
+### sync:site (build docs for site)
+
+Reads `guides/` and `packages/` in this repo and writes React components to the site docs directory.
+
+- **Default output:** `../site/src/pages/docs` (when run from this repo, assumes site is a sibling directory).
+- **Custom output:** set `DOCS_SITE_OUTPUT` to the absolute path of the site’s docs folder (e.g. when the site is in a different repo).
+
+```bash
+bun run sync:site
+# Or with a custom site path:
+DOCS_SITE_OUTPUT=/path/to/site/src/pages/docs bun run sync:site
+```
+
+The script clears the output directory (except `DocsLayout.tsx`) before generating, so each run leaves only the current docs.
 
 ## Writing Documentation
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,18 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "bunary-documentation",
+      "devDependencies": {
+        "@types/marked": "6.0.0",
+        "marked": "17.0.1",
+      },
+    },
+  },
+  "packages": {
+    "@types/marked": ["@types/marked@6.0.0", "", { "dependencies": { "marked": "*" } }, "sha512-jmjpa4BwUsmhxcfsgUit/7A9KbrC48Q0q8KvnY107ogcjGgTFDlIL3RpihNpx2Mu1hM4mdFQjoVc4O6JoGKHsA=="],
+
+    "marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,8 +5,14 @@
   "type": "module",
   "scripts": {
     "sync:packages": "bun scripts/sync-packages.ts",
+    "sync:site": "bun scripts/sync-site.ts",
+    "sync": "bun run sync:packages && bun run sync:site",
     "test": "bun test",
     "test:sync:packages": "bun test \"$PWD/scripts/sync-packages.test.ts\""
+  },
+  "devDependencies": {
+    "@types/marked": "6.0.0",
+    "marked": "17.0.1"
   }
 }
 

--- a/scripts/sync-site.ts
+++ b/scripts/sync-site.ts
@@ -1,0 +1,271 @@
+#!/usr/bin/env bun
+/**
+ * Build docs for the site: convert markdown (guides/ + packages/) to React components.
+ *
+ * Run from the documentation repo root. Reads from this repo (guides/, packages/)
+ * and writes to the site docs output directory.
+ *
+ * Output path: DOCS_SITE_OUTPUT env, or ../site/src/pages/docs when run from documentation/.
+ *
+ * @example
+ * ```bash
+ * bun run sync:site
+ * DOCS_SITE_OUTPUT=/path/to/site/src/pages/docs bun run sync:site
+ * ```
+ */
+
+import { readdir, readFile, writeFile, mkdir, rm } from "fs/promises";
+import { join, dirname, basename, relative } from "path";
+import { existsSync } from "fs";
+import { marked } from "marked";
+
+/** Documentation repo root (cwd when run from documentation/) */
+const DOCS_DIR = process.cwd();
+/** Site docs output: env or sibling ../site/src/pages/docs */
+const OUTPUT_DIR =
+	process.env.DOCS_SITE_OUTPUT ?? join(DOCS_DIR, "..", "site", "src", "pages", "docs");
+
+interface DocMetadata {
+	title: string;
+	description: string;
+}
+
+function parseFrontmatter(content: string): { metadata: DocMetadata; body: string } {
+	const frontmatterRegex = /^---\n([\s\S]*?)\n---\n([\s\S]*)$/;
+	const match = content.match(frontmatterRegex);
+
+	if (!match) {
+		const h1Match = content.match(/^#\s+(.+)$/m);
+		const title = h1Match ? h1Match[1].trim() : basename(content, ".md");
+		const afterH1 = content.replace(/^#\s+.*?\n+/, "").trim();
+		const pMatch = afterH1.match(/^([^\n]+?)(?:\n\n|\n##|$)/);
+		const description = pMatch ? pMatch[1].trim() : "";
+		return { metadata: { title, description }, body: content };
+	}
+
+	const frontmatter = match[1];
+	const body = match[2];
+	const metadata: DocMetadata = { title: "", description: "" };
+	for (const line of frontmatter.split("\n")) {
+		const m = line.match(/^(\w+):\s*(.+)$/);
+		if (m) {
+			const [, key, value] = m;
+			const clean = value.replace(/^["']|["']$/g, "");
+			if (key === "title") metadata.title = clean;
+			if (key === "description") metadata.description = clean;
+		}
+	}
+	return { metadata, body };
+}
+
+function processCodeBlocks(markdown: string): string {
+	return markdown;
+}
+
+async function markdownToReactComponent(
+	metadata: DocMetadata,
+	markdown: string,
+	componentName: string,
+): Promise<string> {
+	let processedMarkdown = markdown.replace(/^#\s+.*?\n+/m, "");
+	if (metadata.description) {
+		processedMarkdown = processedMarkdown.trimStart();
+		const firstParagraphRegex = /^[^\n]+(?:\n\n|\n##|$)/m;
+		const match = processedMarkdown.match(firstParagraphRegex);
+		if (match) {
+			const firstPara = match[0].replace(/\n\n$/, "").trim();
+			const firstParaText = firstPara.replace(/\[([^\]]+)\]\([^\)]+\)/g, "$1");
+			const descText = metadata.description.replace(/\[([^\]]+)\]\([^\)]+\)/g, "$1");
+			if (firstParaText.trim() === descText.trim()) {
+				processedMarkdown = processedMarkdown.replace(firstParagraphRegex, "").trimStart();
+			}
+		}
+	}
+	processedMarkdown = processCodeBlocks(processedMarkdown);
+	const escapedMarkdown = processedMarkdown
+		.replace(/\\/g, "\\\\")
+		.replace(/`/g, "\\`")
+		.replace(/\${/g, "\\${");
+
+	return `/**
+ * ${metadata.title}
+ * ${metadata.description}
+ * Auto-generated from markdown. Do not edit directly.
+ */
+
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { markdownComponents } from "@/components/markdown-components";
+
+const ${componentName} = () => {
+  const markdown = \`${escapedMarkdown}\`;
+  return (
+    <article className="max-w-none">
+      <h1 className="text-4xl font-bold text-foreground mb-4">${metadata.title}</h1>
+      ${metadata.description ? `<p className="text-xl text-muted-foreground mb-8">${metadata.description}</p>` : ""}
+      <div className="prose prose-invert max-w-none prose-headings:text-foreground prose-p:text-muted-foreground prose-a:text-primary prose-strong:text-foreground prose-code:text-foreground prose-code:bg-muted prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-pre:bg-card prose-pre:border prose-pre:border-border prose-pre:rounded-lg prose-pre:p-4">
+        <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+          {markdown}
+        </ReactMarkdown>
+      </div>
+    </article>
+  );
+};
+
+export default ${componentName};
+`;
+}
+
+interface ProcessedFile {
+	componentName: string;
+	exportName: string;
+	filePath: string;
+	isPackage: boolean;
+}
+
+const processedFiles: ProcessedFile[] = [];
+
+async function processMarkdownFile(filePath: string, relativePath: string): Promise<void> {
+	const content = await readFile(filePath, "utf-8");
+	const { metadata, body } = parseFrontmatter(content);
+	const basenameWithoutExt = basename(filePath, ".md");
+	const isPackage = relativePath.startsWith("packages/");
+
+	let componentName: string;
+	let exportName: string;
+	let outputPath: string;
+
+	if (isPackage) {
+		const fileName = basenameWithoutExt
+			.split("-")
+			.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+			.join("");
+		componentName = `${fileName}Package`;
+		exportName = componentName;
+		const outputDir = join(OUTPUT_DIR, "packages");
+		if (!existsSync(outputDir)) await mkdir(outputDir, { recursive: true });
+		outputPath = join(outputDir, `${fileName}.tsx`);
+	} else {
+		const guidePath = relativePath.replace(/^guides\//, "").replace(/\.md$/, "");
+		const pathParts = guidePath.split("/").map((p) => p.replace(/\.md$/, ""));
+
+		if (basenameWithoutExt === "index" && pathParts.length > 1) {
+			componentName = pathParts[0]
+				.split("-")
+				.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+				.join("");
+		} else {
+			componentName = pathParts
+				.map((part) => {
+					const name = part === "index" ? "" : part;
+					return name
+						.split("-")
+						.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+						.join("");
+				})
+				.filter(Boolean)
+				.join("");
+		}
+		exportName = componentName;
+
+		if (pathParts.length > 1) {
+			const outputDir = join(OUTPUT_DIR, pathParts[0]);
+			if (!existsSync(outputDir)) await mkdir(outputDir, { recursive: true });
+			const fileName =
+				basenameWithoutExt === "index"
+					? "index"
+					: basenameWithoutExt
+							.split("-")
+							.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+							.join("");
+			outputPath = join(outputDir, `${fileName}.tsx`);
+		} else {
+			const fileName = basenameWithoutExt
+				.split("-")
+				.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+				.join("");
+			outputPath = join(OUTPUT_DIR, `${fileName}.tsx`);
+		}
+	}
+
+	const component = await markdownToReactComponent(metadata, body, componentName);
+	await writeFile(outputPath, component, "utf-8");
+	processedFiles.push({ componentName, exportName, filePath: outputPath, isPackage });
+	console.log(`✓ Generated ${outputPath}`);
+}
+
+async function processDirectory(dir: string, relativePath: string = ""): Promise<void> {
+	const entries = await readdir(dir, { withFileTypes: true });
+	for (const entry of entries) {
+		const fullPath = join(dir, entry.name);
+		const newRelative = relativePath ? join(relativePath, entry.name) : entry.name;
+		if (entry.isDirectory()) {
+			await processDirectory(fullPath, newRelative);
+		} else if (entry.name.endsWith(".md")) {
+			await processMarkdownFile(fullPath, newRelative);
+		}
+	}
+}
+
+async function generateIndexFile(): Promise<void> {
+	const guides = processedFiles.filter((f) => !f.isPackage).sort((a, b) => a.componentName.localeCompare(b.componentName));
+	const packages = processedFiles.filter((f) => f.isPackage).sort((a, b) => a.componentName.localeCompare(b.componentName));
+	const exports: string[] = [];
+	for (const file of guides) {
+		const rel = relative(OUTPUT_DIR, file.filePath).replace(/\\/g, "/");
+		const importPath = rel.replace(/\.tsx$/, ".js");
+		exports.push(`export { default as ${file.exportName} } from "./${importPath}";`);
+	}
+	if (packages.length > 0) {
+		exports.push("");
+		for (const file of packages) {
+			exports.push(`export { default as ${file.exportName} } from "./packages/${basename(file.filePath, ".tsx")}.js";`);
+		}
+	}
+	const indexContent = `/**
+ * Documentation pages - auto-generated. Do not edit directly.
+ */
+
+export { default as DocsLayout } from "./DocsLayout.js";
+
+${exports.join("\n")}
+`;
+	await writeFile(join(OUTPUT_DIR, "index.ts"), indexContent, "utf-8");
+	console.log("✓ Generated index.ts");
+}
+
+/** Remove generated files so each run leaves only current output. Keeps DocsLayout.tsx. */
+async function cleanOutputDir(): Promise<void> {
+	if (!existsSync(OUTPUT_DIR)) return;
+	const entries = await readdir(OUTPUT_DIR, { withFileTypes: true });
+	for (const entry of entries) {
+		if (entry.name === "DocsLayout.tsx" || entry.name === "DocsLayout.ts") continue;
+		const full = join(OUTPUT_DIR, entry.name);
+		await rm(full, { recursive: true });
+	}
+}
+
+async function build(): Promise<void> {
+	console.log("📚 Building docs for site...\n");
+	console.log(`  Source: ${DOCS_DIR}`);
+	console.log(`  Output: ${OUTPUT_DIR}\n`);
+
+	processedFiles.length = 0;
+
+	if (!existsSync(OUTPUT_DIR)) {
+		await mkdir(OUTPUT_DIR, { recursive: true });
+	} else {
+		await cleanOutputDir();
+	}
+
+	await processDirectory(join(DOCS_DIR, "guides"), "guides");
+	await processDirectory(join(DOCS_DIR, "packages"), "packages");
+	await generateIndexFile();
+
+	console.log(`\n✅ Site docs build complete! (${processedFiles.length} files)`);
+}
+
+build().catch((err) => {
+	console.error("❌ Build failed:", err);
+	process.exit(1);
+});


### PR DESCRIPTION
**Closes #30**

All build/sync scripts live in this repo and are run from the documentation repo root.

**Added:**
- `scripts/sync-site.ts` — builds guides + packages markdown into React components for the site
  - Source: this repo (guides/, packages/)
  - Output: `DOCS_SITE_OUTPUT` or `../site/src/pages/docs`
  - Cleans output dir (keeps DocsLayout) before generating
- `bun run sync:site` — run the site docs build
- `bun run sync` — run sync:packages then sync:site
- README updated with commands table and sync:site docs
- devDependencies: marked, @types/marked
- .gitignore for node_modules