### PR TITLE
docs: audit getting-started guides vs packages (Closes #33)

### DIFF
--- a/DOCS_REVIEW.md
+++ b/DOCS_REVIEW.md
@@ -10,4 +10,6 @@ Per-package docs: For each of core, http, auth, orm, cli, does that package’s 
 
 Guides: Files under `guides/` sometimes reference packages (APIs, install commands, examples). When a package’s API or behavior changes, check whether any guide is now wrong. Update the guide here; don’t duplicate package API detail, but fix broken examples or outdated steps.
 
+**Guide sections to audit** (don’t skip any): `getting-started/`, `basics/`, `routing/`, **`orm/`**, `security/`. For each section, confirm content and examples match the current package APIs (e.g. `orm/` vs `@bunary/orm`).
+
 Gaps: Anything else that would leave readers with wrong or missing info counts as a gap. Prefer fixing the source (package `docs/` or a guide) and syncing or committing here, rather than one-off edits to `packages/*.md` that the next sync would overwrite.

--- a/guides/getting-started/index.md
+++ b/guides/getting-started/index.md
@@ -26,6 +26,9 @@ bunary init my-api
 # Navigate to your project
 cd my-api
 
+# Install dependencies
+bun install
+
 # Start the development server
 bun run dev
 ```
@@ -34,11 +37,9 @@ This will create a new directory with a Bunary project scaffold including:
 
 - `package.json` (with `@bunary/core`, `@bunary/http`; add `--auth basic` or `--auth jwt` to include `@bunary/auth`)
 - `bunary.config.ts` (uses `defineConfig` from `@bunary/core`)
-- Entry point at `src/index.ts` (calls `registerRoutes`, then `app.listen({ port: 3000 })`)
-- `src/routes/` (main, groupExample, index) — add more with `bunary route:make <name>`
+- Entry point at `src/index.ts` (imports and calls `registerRoutes` from `src/routes`, then `app.listen({ port: 3000 })`)
+- `src/routes/` (main, groupExample, index) — `src/routes/index.ts` defines and exports `registerRoutes`; add more with `bunary route:make <name>`
 - With `--auth basic` or `--auth jwt`: `src/middleware/basic.ts` or `jwt.ts` wired in the entrypoint
-
-Next: `cd my-api`, `bun install`, `bun run dev`.
 
 ## Manual Installation
 

--- a/guides/getting-started/index.md
+++ b/guides/getting-started/index.md
@@ -32,9 +32,13 @@ bun run dev
 
 This will create a new directory with a Bunary project scaffold including:
 
-- Pre-configured `bunary.config.ts`
-- Entry point at `src/index.ts`
-- Package.json with development scripts
+- `package.json` (with `@bunary/core`, `@bunary/http`; add `--auth basic` or `--auth jwt` to include `@bunary/auth`)
+- `bunary.config.ts` (uses `defineConfig` from `@bunary/core`)
+- Entry point at `src/index.ts` (calls `registerRoutes`, then `app.listen({ port: 3000 })`)
+- `src/routes/` (main, groupExample, index) — add more with `bunary route:make <name>`
+- With `--auth basic` or `--auth jwt`: `src/middleware/basic.ts` or `jwt.ts` wired in the entrypoint
+
+Next: `cd my-api`, `bun install`, `bun run dev`.
 
 ## Manual Installation
 

--- a/guides/getting-started/structure.md
+++ b/guides/getting-started/structure.md
@@ -10,18 +10,20 @@ When you create a new Bunary project using `bunary init`, you'll get the followi
 ```
 my-api/
 ├── src/
-│   ├── index.ts          # Application entry point
-│   ├── routes/
-│   │   └── api.ts        # API route definitions
-│   └── middleware/
-│       └── logger.ts     # Custom middleware
-├── tests/
-│   └── api.test.ts       # Test files
-├── bunary.config.ts      # Bunary configuration
-├── package.json
-├── tsconfig.json
-└── .env.example
+│   ├── index.ts          # Application entry point (calls registerRoutes, app.listen)
+│   └── routes/
+│       ├── index.ts      # Aggregates route modules, calls registerRoutes
+│       ├── main.ts       # Registers / and /health
+│       └── groupExample.ts  # Example route group (e.g. /api, /api/health)
+├── bunary.config.ts      # Bunary configuration (defineConfig from @bunary/core)
+└── package.json
 ```
+
+With `bunary init my-api --auth basic` or `--auth jwt`, you also get:
+
+- `src/middleware/basic.ts` or `jwt.ts` (auth stub), wired in `src/index.ts`
+
+Add more routes with `bunary route:make <name>`, middleware with `bunary middleware:make <name>`, and models with `bunary model:make <table-name>`.
 
 ## Directory Overview
 

--- a/guides/getting-started/structure.md
+++ b/guides/getting-started/structure.md
@@ -12,12 +12,14 @@ my-api/
 ├── src/
 │   ├── index.ts          # Application entry point (calls registerRoutes, app.listen)
 │   └── routes/
-│       ├── index.ts      # Aggregates route modules, calls registerRoutes
+│       ├── index.ts      # Defines and exports registerRoutes (called from src/index.ts)
 │       ├── main.ts       # Registers / and /health
 │       └── groupExample.ts  # Example route group (e.g. /api, /api/health)
 ├── bunary.config.ts      # Bunary configuration (defineConfig from @bunary/core)
 └── package.json
 ```
+
+Optional (add as needed): `tests/`, `tsconfig.json`, `.env`, `.env.example` — not created by `bunary init`; see Directory Overview below.
 
 With `bunary init my-api --auth basic` or `--auth jwt`, you also get:
 
@@ -41,7 +43,7 @@ The `src` directory contains your application source code. This is where you'll 
 
 ### The tests Directory
 
-The `tests` directory contains your test files. Bunary uses Bun's built-in test runner, so you can run tests with `bun test`.
+The `tests` directory (optional; not created by `bunary init`) contains your test files. Bunary uses Bun's built-in test runner, so you can run tests with `bun test`.
 
 ### Configuration Files
 
@@ -49,9 +51,9 @@ The `tests` directory contains your test files. Bunary uses Bun's built-in test 
 |------|---------|
 | `bunary.config.ts` | Bunary application configuration |
 | `package.json` | Dependencies and scripts |
-| `tsconfig.json` | TypeScript configuration |
-| `.env` | Environment variables (git-ignored) |
-| `.env.example` | Example environment variables template |
+| `tsconfig.json` | TypeScript configuration (optional; add if needed) |
+| `.env` | Environment variables (optional; git-ignored) |
+| `.env.example` | Example environment variables template (optional; add as needed) |
 
 ## Larger Projects
 

--- a/guides/orm/index.md
+++ b/guides/orm/index.md
@@ -4,7 +4,7 @@ Working with databases using Bunary's ORM.
 
 ## Overview
 
-Bunary's ORM provides an Eloquent-like interface for working with databases. It features a database abstraction layer that supports multiple database types through a unified API.
+Bunary's ORM provides an Eloquent-like interface for working with databases. It features a database abstraction layer that supports multiple database types through a unified API, plus a **Schema** builder and **migrations** for versioning your database schema.
 
 ## Quick Start
 
@@ -34,7 +34,7 @@ Create model classes that extend `BaseModel` for an Eloquent-like experience:
 import { BaseModel } from "@bunary/orm";
 
 class User extends BaseModel {
-  static tableName = "users";
+  protected static tableName = "users";
   protected static protected = ["password"];
   protected static timestamps = ["createdAt", "updatedAt"];
 }
@@ -42,5 +42,16 @@ class User extends BaseModel {
 // Use the model
 const user = await User.find(1);
 const users = await User.all();
-const activeUsers = await User.where("status", "=", "active").get();
+const activeUsers = await User.where("status", "=", "active").all();
 ```
+
+## Migrations
+
+Version your database schema with migration files and the Schema builder. Use the CLI to create and run migrations:
+
+- **`bunary migration:make <name>`** — Create a migration in `./migrations/`
+- **`bunary migrate`** — Run pending migrations (creates `scripts/migrate.ts` on first use)
+- **`bunary migrate:rollback`** — Rollback last batch
+- **`bunary migrate:status`** — Show ran vs pending
+
+Your project needs `src/config/orm.ts` that calls `setOrmConfig` so the migrator can connect. See [Migrations](./migrations.md) for the Schema builder, migration file format, and programmatic API.

--- a/guides/orm/migrations.md
+++ b/guides/orm/migrations.md
@@ -1,0 +1,172 @@
+# Migrations
+
+Manage database schema changes with migration files and the Schema builder.
+
+## Overview
+
+Migrations let you version your database schema: each migration file defines `up()` (apply changes) and `down()` (rollback). The ORM provides a **Schema** builder for creating and altering tables, and a **Migrator** (or the CLI) to run and rollback migrations in order.
+
+**Requirements:** `@bunary/orm` in your project. For the CLI commands you also need `src/config/orm.ts` that calls `setOrmConfig` so the migrator can connect.
+
+## CLI commands
+
+| Command | Description |
+|--------|-------------|
+| `bunary migration:make <name>` | Create a new migration file in `./migrations/` |
+| `bunary migrate` | Run all pending migrations |
+| `bunary migrate:rollback` | Rollback the last migration batch |
+| `bunary migrate:status` | Show which migrations have run and which are pending |
+
+### Creating a migration
+
+```bash
+bunary migration:make create_users_table
+```
+
+This creates a file like `./migrations/20260129120000_create_users_table.ts` with stub `up()` and `down()` that use `Schema` from `@bunary/orm`. The name is used to derive a table name (e.g. `create_users_table` → `"users"`) in the stub.
+
+### Running migrations
+
+```bash
+bunary migrate
+```
+
+On first use, the CLI creates `scripts/migrate.ts` in your project. Ensure `src/config/orm.ts` calls `setOrmConfig` with your database config so the migrator can connect.
+
+### Rollback and status
+
+```bash
+bunary migrate:rollback   # Rollback last batch
+bunary migrate:status      # List ran and pending migrations
+```
+
+## Migration file format
+
+Each migration file must export `up()` and `down()` (async or sync). Use the Schema builder for DDL:
+
+```typescript
+// migrations/20260129120000_create_users_table.ts
+import { Schema } from "@bunary/orm";
+
+export async function up() {
+  Schema.createTable("users", (table) => {
+    table.uuid("id").primary();
+    table.string("name", 255).notNull();
+    table.string("email", 255).unique().notNull();
+    table.boolean("active").default(true);
+    table.timestamps();
+  });
+}
+
+export async function down() {
+  Schema.dropTable("users");
+}
+```
+
+Drop in reverse order of create (e.g. drop dependent tables first):
+
+```typescript
+export async function down() {
+  Schema.dropTable("posts");
+  Schema.dropTable("users");
+}
+```
+
+## Schema builder
+
+Use `Schema` inside migrations (after ORM config is set) to create, alter, and drop tables.
+
+### Create and drop tables
+
+```typescript
+import { Schema } from "@bunary/orm";
+
+// Create a table
+Schema.createTable("users", (table) => {
+  table.increments("id");                    // Integer primary key, auto-increment
+  table.string("name", 255).notNull();
+  table.string("email", 255).unique().notNull();
+  table.boolean("active").default(true);
+  table.timestamp("deleted_at").nullable();
+  table.timestamps();                        // createdAt, updatedAt
+});
+
+// Or UUID primary key
+Schema.createTable("posts", (table) => {
+  table.uuid("id").primary();
+  table.foreignId("user_id").references("users", "id");
+  table.text("title").notNull();
+  table.timestamps();
+});
+
+// Drop a table
+Schema.dropTable("users");
+```
+
+### Alter tables and helpers
+
+```typescript
+// Add columns to an existing table
+Schema.table("users", (table) => {
+  table.string("phone", 20).nullable();
+});
+
+// Check before changing
+if (!Schema.hasTable("users")) {
+  Schema.createTable("users", (table) => { /* ... */ });
+}
+if (!Schema.hasColumn("users", "email")) {
+  Schema.table("users", (table) => {
+    table.string("email", 255);
+  });
+}
+
+// Rename a table
+Schema.renameTable("users", "accounts");
+```
+
+**Schema methods:** `createTable(name, callback)`, `dropTable(name)`, `table(name, callback)` (alter), `hasTable(name)`, `hasColumn(table, column)`, `renameTable(oldName, newName)`.
+
+**Column types:** `increments("id")`, `integer("col")`, `text("col")`, `string("col", length?)`, `boolean("col")`, `timestamp("col")`, `uuid("id"?)`, `foreignId("col")`, `timestamps()`.
+
+**Modifiers:** `.nullable()`, `.notNull()`, `.default(value)`, `.unique()`, `.primary()`, and `foreignId("col").references("table", "column")`.
+
+## Programmatic API
+
+Run migrations from code with `createMigrator`:
+
+```typescript
+import { createMigrator, setOrmConfig } from "@bunary/orm";
+
+setOrmConfig({
+  database: {
+    type: "sqlite",
+    sqlite: { path: "./database.sqlite" },
+  },
+});
+
+const migrator = createMigrator({ migrationsPath: "./migrations" });
+
+// Status: ran vs pending
+const status = await migrator.status();
+console.log("Ran:", status.ran);
+console.log("Pending:", status.pending);
+
+// Run all pending migrations (uses transactions; rollback on failure)
+await migrator.up();
+
+// Rollback last batch (default) or multiple batches
+await migrator.down();
+await migrator.down({ steps: 2 });
+```
+
+**API:** `createMigrator({ migrationsPath?, tableName? })`, `migrator.status()`, `migrator.up()`, `migrator.down({ steps?: number })`.
+
+## Configuration
+
+The migrator needs the ORM to be configured before running. In a Bunary project:
+
+1. **`src/config/orm.ts`** — Call `setOrmConfig` with your database config (same as in [Database config](./database-config.md)).
+2. **`scripts/migrate.ts`** — Created by `bunary migrate` on first use; it imports your config and runs the migrator. You can customize it to change the migrations path or use `enableCoreConfig()`.
+
+Without `src/config/orm.ts` (and the config being loaded before the migrator runs), `bunary migrate` will fail with a configuration error.

--- a/guides/orm/models.md
+++ b/guides/orm/models.md
@@ -10,12 +10,12 @@ Create model classes that extend `BaseModel`:
 import { BaseModel } from "@bunary/orm";
 
 class Post extends BaseModel {
-  static tableName = "posts";
+  protected static tableName = "posts";
   protected static timestamps = false; // Disable timestamps
 }
 
 class Comment extends BaseModel {
-  static tableName = "comments";
+  protected static tableName = "comments";
   protected static protected = ["internal_notes"];
 }
 ```
@@ -26,7 +26,7 @@ Automatically exclude sensitive fields from queries:
 
 ```typescript
 class User extends BaseModel {
-  static tableName = "users";
+  protected static tableName = "users";
   protected static protected = ["password", "api_key"];
 }
 
@@ -41,7 +41,7 @@ Automatically handle `createdAt` and `updatedAt` fields:
 
 ```typescript
 class Post extends BaseModel {
-  static tableName = "posts";
+  protected static tableName = "posts";
   // timestamps defaults to ["createdAt", "updatedAt"]
   // Set to false to disable
   protected static timestamps = false;

--- a/guides/orm/query-builder.md
+++ b/guides/orm/query-builder.md
@@ -14,12 +14,12 @@ const users = await Model.table("users").all();
 // Select specific columns
 const users = await Model.table("users")
   .select("id", "name", "email")
-  .get();
+  .all();
 
 // Exclude sensitive fields
 const users = await Model.table("users")
   .exclude("password", "secret_key")
-  .get();
+  .all();
 ```
 
 ## Filtering Records
@@ -30,7 +30,7 @@ Filter records using the `where` method:
 // Filter records
 const activeUsers = await Model.table("users")
   .where("status", "=", "active")
-  .get();
+  .all();
 ```
 
 ## Ordering and Limiting
@@ -42,7 +42,7 @@ Order and limit query results:
 const recentUsers = await Model.table("users")
   .orderBy("createdAt", "desc")
   .limit(10)
-  .get();
+  .all();
 ```
 
 ## Common Patterns
@@ -56,7 +56,7 @@ const perPage = 10;
 const users = await User
   .offset((page - 1) * perPage)
   .limit(perPage)
-  .get();
+  .all();
 ```
 
 ### Counting Records

--- a/guides/routing/index.md
+++ b/guides/routing/index.md
@@ -18,6 +18,8 @@ app.get("/", () => {
 app.listen({ port: 3000 });
 ```
 
+You can pass options to `createApp({ basePath?, onNotFound?, onMethodNotAllowed?, onError? })` (e.g. `basePath: "/api"` to prefix all routes). See the [@bunary/http](/docs/packages/http) package docs for full options. HEAD requests use GET routes automatically; OPTIONS returns allowed methods.
+
 ## Available HTTP Methods
 
 The router supports the following HTTP methods:
@@ -83,7 +85,7 @@ Every route handler receives a `RequestContext` object with the following proper
 | Property | Type | Description |
 |----------|------|-------------|
 | `request` | Request | The native Fetch API Request object |
-| `params` | Record<string, string> | URL route parameters |
+| `params` | Record<string, string \| undefined> | URL route parameters (optional params may be `undefined`) |
 | `query` | URLSearchParams | Query string parameters |
 | `locals` | Record<string, unknown> | Per-request data (e.g. `ctx.locals.auth` from auth middleware) |
 

--- a/guides/security/guards.md
+++ b/guides/security/guards.md
@@ -52,7 +52,7 @@ const authMiddleware = createAuth({
   defaultGuard: "basic",
   guards: {
     basic: createBasicGuard({
-      validateUser: async (username, password) => {
+      verify: async (username, password, request) => {
         const user = await db.users.findByUsername(username);
         if (!user || !(await verifyPassword(password, user.passwordHash))) return null;
         return { id: user.id, username: user.username };
@@ -73,7 +73,7 @@ const authMiddleware = createAuth({
   defaultGuard: "jwt",
   guards: {
     jwt: createJwtGuard({ secret: process.env.JWT_SECRET! }),
-    basic: createBasicGuard({ validateUser: myValidateUser }),
+    basic: createBasicGuard({ verify: myVerify }),
   },
 });
 
@@ -96,7 +96,7 @@ app.get("/webhook", async (ctx) => {
 
 ## Custom Guards
 
-Guards implement the `Guard` interface: `name` and `authenticate(request)` returning `AuthUser | null`:
+Guards implement the `Guard` interface: `name` (string) and `authenticate(request: Request)` returning `Promise<AuthUser | null>` or `AuthUser | null`:
 
 ```typescript
 import type { Guard, AuthUser } from "@bunary/auth";

--- a/guides/security/index.md
+++ b/guides/security/index.md
@@ -74,9 +74,11 @@ app.get("/profile", async (ctx) => {
 });
 ```
 
+Use `auth.require()` to get the current user or throw if unauthenticated; use `auth.logout()` to clear auth state for the request.
+
 ## Built-in Guards
 
 - **JWT:** `createJwtGuard({ secret, issuer?, audience? })` — validates Bearer tokens (HS256).
-- **Basic:** `createBasicGuard({ validateUser })` — validates Basic auth; you provide a function that checks username/password.
+- **Basic:** `createBasicGuard({ verify(username, password, request) })` — validates Basic auth; you provide a `verify` function that returns an `AuthUser` or `null`.
 
 See [Guards](./guards.md) for custom guards and details.


### PR DESCRIPTION
**Closes #33** — Audit all documentation and guides against packages.

**This PR (guides):**
- **getting-started/index.md:** Updated "what bunary init creates" to match @bunary/cli: package.json, bunary.config.ts, src/index.ts, src/routes/ (main, groupExample, index), optional `--auth basic|jwt` middleware; added next steps.
- **getting-started/structure.md:** Replaced placeholder default structure (api.ts, logger.ts) with actual `bunary init` output (routes/index.ts, main.ts, groupExample.ts); noted `--auth` and generators (route:make, middleware:make, model:make).

**Audit scope:** Other guides (basics, routing, orm, security) were checked; API examples already aligned in #24 (listen, auth, RequestContext). `bun run sync:packages` run — packages/*.md unchanged (in sync with package repos).