### PR TITLE
feat: documentation process v2 — composition, --local mode, frontmatter, bunary-docs skill

### DIFF
--- a/.claude/skills/bunary-docs/SKILL.md
+++ b/.claude/skills/bunary-docs/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: bunary-docs
+description: Use when writing, editing, syncing, reviewing, or auditing Bunary documentation — package docs, guides, or the docs site build — or when a Bunary package API change needs a doc update.
+---
+
+# Bunary documentation workflow
+
+Bunary docs flow through two hops:
+package repo `docs/` → (sync:packages) → `documentation/packages/*.md` → (sync:site) → `site/src/pages/docs/*.tsx`.
+
+## Where to edit — decision table
+
+| You changed / need | Edit here | Never |
+|---|---|---|
+| Package API, feature, CLI command | `packages/{pkg}/docs/index.md` (+ optional `quickstart.md`, `api.md`, `migration.md`) in that package repo | `documentation/packages/*.md` (synced output) |
+| Cross-package tutorial, concepts, getting started | `documentation/guides/**/*.md` | duplicating package API detail in guides |
+| Site chrome, layout, docs shell | `site/` repo (`DocsLayout.tsx` survives rebuilds) | generated `site/src/pages/docs/**` pages |
+
+## Pipeline commands (run from the documentation repo root)
+
+- `bun run sync:packages` — fetch package docs from GitHub main, compose per contract order (`index.md` + `quickstart.md` + `api.md` + `migration.md`), write `packages/*.md`.
+- `bun run scripts/sync-packages.ts --local [root]` — same, but read from local sibling checkouts (default root `../packages`); use to preview unpushed package-doc changes. Never commit locally-sourced `packages/*.md` — committed output must come from the remote sync.
+- `bun run sync:site` — convert guides + packages markdown to React components in the site repo.
+- CI drift check: a PR here must include the `packages/*.md` produced by `bun run sync:packages`, or CI fails.
+
+## Authoring conventions
+
+- Frontmatter on guides: `title`, `description`, `order` (sidebar position within its section). Package docs: optional.
+- `docs/index.md` starts with `# @bunary/{pkg}`.
+- Install snippets show only the one package (`bun add @bunary/http`); dependencies arrive transitively.
+- Example-driven; code fences carry a language (```typescript).
+- A feature PR in a package repo is not done until `docs/` reflects the change; the docs sync PR follows here.
+
+## Drift audit (when asked to review docs)
+
+1. Per package (core, http, auth, orm, cli): compare `docs/index.md` claims against the package's actual exports and JSDoc; fix gaps in the package repo, then sync.
+2. Per guide section (`getting-started/`, `basics/`, `routing/`, `orm/`, `security/`): confirm examples and APIs still match the packages.
+3. Run `bun run sync:packages` and commit any drift.
+4. Details: `DOCS_REVIEW.md`, `PACKAGE_DOCS_CONTRACT.md`, `PUBLISH_WORKFLOW.md` in the documentation repo — those are the source of truth; this skill is the operational summary.

--- a/PACKAGE_DOCS_CONTRACT.md
+++ b/PACKAGE_DOCS_CONTRACT.md
@@ -56,9 +56,9 @@ From this repo root:
 bun run sync:packages
 ```
 
-### MVP mapping (phase 1)
+### Mapping
 
-To start, we sync only `docs/index.md`:
+Each package's doc files are composed into a single output page:
 
 | Package repo | Source | Output (this repo) |
 |---|---|---|

--- a/PACKAGE_DOCS_CONTRACT.md
+++ b/PACKAGE_DOCS_CONTRACT.md
@@ -62,15 +62,15 @@ To start, we sync only `docs/index.md`:
 
 | Package repo | Source | Output (this repo) |
 |---|---|---|
-| `core` | `docs/index.md` | `packages/core.md` |
-| `http` | `docs/index.md` | `packages/http.md` |
-| `auth` | `docs/index.md` | `packages/auth.md` |
-| `orm` | `docs/index.md` | `packages/orm.md` |
-| `cli` | `docs/index.md` | `packages/cli.md` |
+| `core` | `docs/*.md composed` | `packages/core.md` |
+| `http` | `docs/*.md composed` | `packages/http.md` |
+| `auth` | `docs/*.md composed` | `packages/auth.md` |
+| `orm` | `docs/*.md composed` | `packages/orm.md` |
+| `cli` | `docs/*.md composed` | `packages/cli.md` |
 
-### Follow-up mapping (phase 2, optional)
+### Composition (phase 2 — implemented)
 
-Once we support composing multiple source files into a single package page, the sync should concatenate in this order when files exist:
+The sync now concatenates `index.md` + `quickstart.md` + `api.md` + `migration.md` when present; only `index.md` is mandatory. It composes in this order when files exist:
 
 1. `docs/index.md`
 2. `docs/quickstart.md`

--- a/PACKAGE_DOCS_CONTRACT.md
+++ b/PACKAGE_DOCS_CONTRACT.md
@@ -21,7 +21,7 @@ Each package repo MUST contain:
 
 - `docs/index.md`
 
-Each package repo SHOULD contain (recommended, but optional until the sync supports multi-file composition):
+Each package repo SHOULD contain (optional; automatically composed into the package page when present):
 
 - `docs/quickstart.md`
 - `docs/api.md`

--- a/PUBLISH_WORKFLOW.md
+++ b/PUBLISH_WORKFLOW.md
@@ -6,6 +6,8 @@ When to sync: after you merge or release a package change that touched `docs/` o
 
 How to sync: from this repo root run `bun run sync:packages`. The script fetches each package’s `docs/index.md` from GitHub (main) and writes `packages/*.md` here. No local package clones needed. Commit the changed `packages/*.md` and push.
 
+To preview package-doc changes before pushing, run `bun run scripts/sync-packages.ts --local` — it reads the local sibling checkouts instead of GitHub main. Do not commit locally-sourced output; the committed `packages/*.md` must come from the default remote sync.
+
 Who runs it: whoever is doing the release or the follow-up doc pass. There is no automated trigger yet. A practical rule: when you cut a package release or merge a feature that changed docs, run sync and open a PR in this repo with the updated `packages/*.md`, or add “run sync and commit” to the release checklist for that package.
 
 CI: PRs in this repo run a drift check. If `bun run sync:packages` would produce changes but the PR didn’t include them, CI fails. So if a package’s `docs/index.md` changed and you didn’t sync, the next person to touch this repo may hit that failure; then they run sync and commit the result.

--- a/PUBLISH_WORKFLOW.md
+++ b/PUBLISH_WORKFLOW.md
@@ -4,7 +4,7 @@ Package docs live in each package repo under `docs/`. This repo consumes them. W
 
 When to sync: after you merge or release a package change that touched `docs/` or that users need documented. If you added a CLI command, you update `packages/cli/docs/index.md` in the cli repo; then someone runs the sync so `documentation/packages/cli.md` here is updated.
 
-How to sync: from this repo root run `bun run sync:packages`. The script fetches each package’s `docs/index.md` from GitHub (main) and writes `packages/*.md` here. No local package clones needed. Commit the changed `packages/*.md` and push.
+How to sync: from this repo root run `bun run sync:packages`. The script fetches each package’s doc files (`docs/index.md`, plus `quickstart.md`, `api.md`, `migration.md` when present) from GitHub (main), composes them, and writes `packages/*.md` here. No local package clones needed. Commit the changed `packages/*.md` and push.
 
 To preview package-doc changes before pushing, run `bun run scripts/sync-packages.ts --local` — it reads the local sibling checkouts instead of GitHub main. Do not commit locally-sourced output; the committed `packages/*.md` must come from the default remote sync.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ All build/sync scripts live in this repo and are run from the documentation repo
 
 | Command | What it does |
 |--------|----------------|
-| `bun run sync:packages` | Fetch package `docs/index.md` from GitHub and write `packages/*.md` in this repo. |
+| `bun run sync:packages` | Fetch package docs (index + quickstart + api + migration when present) from GitHub and write `packages/*.md`. Add `--local [root]` to read from local sibling checkouts for preview. |
 | `bun run sync:site` | Build guides + packages markdown into React components for the site. Cleans the site docs output dir, then generates. |
 | `bun run sync` | Run `sync:packages` then `sync:site` (full pipeline). |
 
@@ -76,6 +76,8 @@ This will update:
 - `packages/auth.md`
 - `packages/orm.md`
 - `packages/cli.md`
+
+To preview changes against local sibling package checkouts instead of GitHub, run `bun run scripts/sync-packages.ts --local` (bare `--local` defaults to `../packages` relative to the repo root).
 
 ### CI drift check
 
@@ -105,6 +107,7 @@ The script clears the output directory (except `DocsLayout.tsx`) before generati
 - Use standard Markdown syntax
 - Code blocks should specify language: ` ```typescript `
 - Use frontmatter for metadata (title, description, etc.)
+- Frontmatter keys read by `sync:site`: `title`, `description`, `order` (a number that drives export/sidebar ordering). Files without frontmatter keep heading-derived behavior.
 - Keep documentation focused and example-driven
 
 ### Package Documentation

--- a/docs/superpowers/plans/2026-07-06-docs-process-v2.md
+++ b/docs/superpowers/plans/2026-07-06-docs-process-v2.md
@@ -1,0 +1,991 @@
+# Documentation Process v2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the approved docs-process-v2 spec (issue bunary-dev/documentation#45): multi-file package-doc composition, a `--local` sync mode, frontmatter-driven site build ordering, a `bunary-docs` Claude skill, and consolidation onto one md→React converter.
+
+**Architecture:** `scripts/sync-packages.ts` gets a `DocFileLoader` abstraction with two implementations (remote GitHub-raw, local sibling checkouts) and composes up to four doc files per package into one `packages/*.md`. `scripts/sync-site.ts` is refactored into exported, testable functions and learns an `order` frontmatter key used to sort the generated `index.ts` exports. Process knowledge is captured in `.claude/skills/bunary-docs/SKILL.md` (versioned here, copied to the workspace root).
+
+**Tech Stack:** Bun ≥1.0.0, TypeScript, `bun:test`, marked (existing). No new dependencies.
+
+## Global Constraints
+
+- Work happens in the worktree `documentation/.worktrees/45-docs-process-v2` on branch `docs/45-docs-process-v2`. Never commit on main.
+- All commands run from the worktree root unless stated otherwise. Prefix Bash with `cd /home/paul/Projects/OpenSource/BunaryDev/documentation/.worktrees/45-docs-process-v2 &&`.
+- Conventional Commits for every commit message.
+- TDD: failing test first, then implementation. Full suite (`bun test`) green before the PR; report the passing count.
+- Remote fetch stays the **default** sync mode — CI drift-check semantics must not change.
+- Only `docs/index.md` is mandatory per package; `quickstart.md`, `api.md`, `migration.md` are optional and composed in exactly that order (PACKAGE_DOCS_CONTRACT phase 2).
+- Files without frontmatter must keep today's derived-from-heading behaviour (non-breaking).
+- Biome for lint (`bunx biome check ./scripts`); tabs for indentation (match existing files).
+
+---
+
+### Task 1: Loader abstraction + multi-file composition in sync-packages
+
+**Files:**
+- Modify: `scripts/sync-packages.ts`
+- Test: `scripts/sync-packages.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces (used by Task 2 and the CLI):
+  - `DOC_FILE_ORDER: readonly string[]` — `["index.md", "quickstart.md", "api.md", "migration.md"]`
+  - `type DocFileLoader = { describeSource(repo: string, file: string): string; loadFile(repo: string, file: string): Promise<string | null> }` (null = file does not exist)
+  - `createRemoteLoader(fetchImpl?: typeof fetch): DocFileLoader`
+  - `composePackageDocs(repo: string, loader: DocFileLoader): Promise<{ sources: string[]; markdown: string } | null>` (null = mandatory `index.md` missing)
+  - `renderSyncedPackageMarkdown(args: { generatorCommand: string; sources: string[]; sourceMarkdown: string }): string` (**breaking change**: `sources: string[]` replaces `sourceUrl: string`)
+  - `syncPackages(options)` where `SyncPackagesOptions` gains `loader?: DocFileLoader` and **drops** `fetchText`; `SyncTarget` drops `sourceUrl` (now `{ repo, outputFileName }`)
+
+- [ ] **Step 1: Rewrite the test file with failing tests for composition**
+
+Replace the entire contents of `scripts/sync-packages.test.ts` with:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import {
+	composePackageDocs,
+	createRemoteLoader,
+	DOC_FILE_ORDER,
+	renderSyncedPackageMarkdown,
+	SYNC_TARGETS,
+	syncPackages,
+	type DocFileLoader,
+} from "./sync-packages";
+
+/** In-memory loader: files maps "repo/file" → content. */
+function memoryLoader(files: Record<string, string>): DocFileLoader {
+	return {
+		describeSource: (repo, file) => `mem://${repo}/docs/${file}`,
+		loadFile: async (repo, file) => files[`${repo}/${file}`] ?? null,
+	};
+}
+
+describe("documentation sync: composition", () => {
+	test("DOC_FILE_ORDER is the contract phase-2 order", () => {
+		expect(DOC_FILE_ORDER).toEqual(["index.md", "quickstart.md", "api.md", "migration.md"]);
+	});
+
+	test("composePackageDocs() concatenates existing files in contract order", async () => {
+		const loader = memoryLoader({
+			"http/index.md": "# @bunary/http\n",
+			"http/api.md": "## API\n",
+			"http/quickstart.md": "## Quickstart\n",
+		});
+		const result = await composePackageDocs("http", loader);
+		expect(result).not.toBeNull();
+		const markdown = result!.markdown;
+		expect(markdown.indexOf("# @bunary/http")).toBeLessThan(markdown.indexOf("## Quickstart"));
+		expect(markdown.indexOf("## Quickstart")).toBeLessThan(markdown.indexOf("## API"));
+		expect(result!.sources).toEqual([
+			"mem://http/docs/index.md",
+			"mem://http/docs/quickstart.md",
+			"mem://http/docs/api.md",
+		]);
+	});
+
+	test("composePackageDocs() returns null when index.md is missing", async () => {
+		const loader = memoryLoader({ "http/api.md": "## API\n" });
+		expect(await composePackageDocs("http", loader)).toBeNull();
+	});
+
+	test("renderSyncedPackageMarkdown() lists every source in the header", () => {
+		const out = renderSyncedPackageMarkdown({
+			generatorCommand: "bun run sync:packages",
+			sources: ["mem://core/docs/index.md", "mem://core/docs/api.md"],
+			sourceMarkdown: "# @bunary/core\n\nHello\n",
+		});
+		expect(out).toContain("AUTO-GENERATED");
+		expect(out).toContain("mem://core/docs/index.md");
+		expect(out).toContain("mem://core/docs/api.md");
+		expect(out).toContain("# @bunary/core");
+		expect(out.endsWith("\n")).toBe(true);
+	});
+
+	test("syncPackages() writes packages/*.md for all targets", async () => {
+		const writes = new Map<string, string>();
+		const files: Record<string, string> = {};
+		for (const t of SYNC_TARGETS) files[`${t.repo}/index.md`] = `# @bunary/${t.repo}\n`;
+
+		await syncPackages({
+			repoRootDir: "/repo",
+			loader: memoryLoader(files),
+			writeFile: async (absolutePath, content) => {
+				writes.set(absolutePath, content);
+			},
+		});
+
+		for (const target of SYNC_TARGETS) {
+			const outPath = `/repo/packages/${target.outputFileName}`;
+			expect(writes.has(outPath)).toBe(true);
+			expect(writes.get(outPath)).toContain(`# @bunary/${target.repo}`);
+		}
+	});
+
+	test("syncPackages() skips packages missing index.md when strict=false", async () => {
+		const writes = new Map<string, string>();
+		await syncPackages({
+			repoRootDir: "/repo",
+			strict: false,
+			targets: [{ repo: "cli", outputFileName: "cli.md" }],
+			loader: memoryLoader({}),
+			writeFile: async (absolutePath, content) => {
+				writes.set(absolutePath, content);
+			},
+		});
+		expect(writes.size).toBe(0);
+	});
+
+	test("syncPackages() throws on missing index.md when strict=true", async () => {
+		expect(
+			syncPackages({
+				repoRootDir: "/repo",
+				strict: true,
+				targets: [{ repo: "cli", outputFileName: "cli.md" }],
+				loader: memoryLoader({}),
+				writeFile: async () => {},
+			}),
+		).rejects.toThrow(/cli/);
+	});
+
+	test("createRemoteLoader() returns null on 404 and content on 200", async () => {
+		const fakeFetch = (async (url: string | URL | Request) => {
+			const u = String(url);
+			if (u.endsWith("quickstart.md")) return new Response("nope", { status: 404 });
+			return new Response(`# from ${u}`, { status: 200 });
+		}) as typeof fetch;
+		const loader = createRemoteLoader(fakeFetch);
+		expect(await loader.loadFile("core", "quickstart.md")).toBeNull();
+		expect(await loader.loadFile("core", "index.md")).toContain("# from ");
+		expect(loader.describeSource("core", "index.md")).toBe(
+			"https://raw.githubusercontent.com/bunary-dev/core/main/docs/index.md",
+		);
+	});
+
+	test("createRemoteLoader() throws on non-404 errors", async () => {
+		const fakeFetch = (async () => new Response("boom", { status: 500 })) as typeof fetch;
+		const loader = createRemoteLoader(fakeFetch);
+		expect(loader.loadFile("core", "index.md")).rejects.toThrow(/500/);
+	});
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test scripts/sync-packages.test.ts`
+Expected: FAIL — `composePackageDocs`, `createRemoteLoader`, `DOC_FILE_ORDER` are not exported; `SyncTarget` still requires `sourceUrl`.
+
+- [ ] **Step 3: Rewrite sync-packages.ts with the loader abstraction**
+
+Replace the entire contents of `scripts/sync-packages.ts` with:
+
+```typescript
+#!/usr/bin/env bun
+/**
+ * Sync package docs from package repos into this repo's `packages/*.md`.
+ *
+ * Source-of-truth: each package repo's `docs/` directory. Per package we compose
+ * (in order): index.md (mandatory), quickstart.md, api.md, migration.md (optional).
+ *
+ * Default mode fetches from GitHub main. `--local [root]` reads from local
+ * sibling checkouts instead (root defaults to ../packages) so doc changes can
+ * be previewed before pushing.
+ *
+ * @example
+ * ```bash
+ * bun run sync:packages
+ * bun run sync:packages --local
+ * bun run sync:packages --local /path/to/packages
+ * ```
+ */
+
+import { mkdir, readFile, writeFile } from "fs/promises";
+import { dirname, join, resolve } from "path";
+
+/** Contract phase-2 composition order. Only index.md is mandatory. */
+export const DOC_FILE_ORDER: ReadonlyArray<string> = Object.freeze([
+	"index.md",
+	"quickstart.md",
+	"api.md",
+	"migration.md",
+]);
+
+export type SyncTarget = Readonly<{
+	/** GitHub repository name under `bunary-dev/` (e.g. `core`, `http`). */
+	repo: string;
+	/** Output filename under `packages/` (e.g. `core.md`). */
+	outputFileName: string;
+}>;
+
+/**
+ * Deterministic list of package docs we sync.
+ * Extending this list is the only change needed to sync another package.
+ */
+export const SYNC_TARGETS: ReadonlyArray<SyncTarget> = Object.freeze([
+	{ repo: "core", outputFileName: "core.md" },
+	{ repo: "http", outputFileName: "http.md" },
+	{ repo: "auth", outputFileName: "auth.md" },
+	{ repo: "orm", outputFileName: "orm.md" },
+	{ repo: "cli", outputFileName: "cli.md" },
+]);
+
+/**
+ * Loads package doc files from some source (GitHub raw, local checkout, memory).
+ * `loadFile` resolves `null` when the file does not exist at the source.
+ */
+export type DocFileLoader = Readonly<{
+	describeSource: (repo: string, file: string) => string;
+	loadFile: (repo: string, file: string) => Promise<string | null>;
+}>;
+
+/**
+ * Loader that fetches from GitHub raw (main branch). 404 → null; other
+ * non-OK responses throw.
+ */
+export function createRemoteLoader(fetchImpl: typeof fetch = fetch): DocFileLoader {
+	const urlFor = (repo: string, file: string) =>
+		`https://raw.githubusercontent.com/bunary-dev/${repo}/main/docs/${file}`;
+	return {
+		describeSource: urlFor,
+		loadFile: async (repo, file) => {
+			const url = urlFor(repo, file);
+			const res = await fetchImpl(url);
+			if (res.status === 404) return null;
+			if (!res.ok) {
+				throw new Error(`Failed to fetch "${url}" (${res.status} ${res.statusText})`);
+			}
+			return await res.text();
+		},
+	};
+}
+
+/**
+ * Loader that reads from local package checkouts: `<root>/<repo>/docs/<file>`.
+ * Missing file (ENOENT) → null; other filesystem errors throw.
+ */
+export function createLocalLoader(
+	packagesRootDir: string,
+	readFileImpl: (path: string) => Promise<string> = (path) => readFile(path, "utf-8"),
+): DocFileLoader {
+	const pathFor = (repo: string, file: string) => join(packagesRootDir, repo, "docs", file);
+	return {
+		describeSource: pathFor,
+		loadFile: async (repo, file) => {
+			try {
+				return await readFileImpl(pathFor(repo, file));
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+				throw error;
+			}
+		},
+	};
+}
+
+/**
+ * Compose one package page from its doc files in DOC_FILE_ORDER.
+ * Returns null when the mandatory index.md is missing.
+ */
+export async function composePackageDocs(
+	repo: string,
+	loader: DocFileLoader,
+): Promise<{ sources: string[]; markdown: string } | null> {
+	const parts: string[] = [];
+	const sources: string[] = [];
+	for (const file of DOC_FILE_ORDER) {
+		const content = await loader.loadFile(repo, file);
+		if (content === null) {
+			if (file === "index.md") return null;
+			continue;
+		}
+		parts.push(normalizeNewlines(content).trim());
+		sources.push(loader.describeSource(repo, file));
+	}
+	return { sources, markdown: `${parts.join("\n\n")}\n` };
+}
+
+export type RenderSyncedPackageMarkdownArgs = Readonly<{
+	generatorCommand: string;
+	sources: ReadonlyArray<string>;
+	sourceMarkdown: string;
+}>;
+
+/**
+ * Render the markdown we commit into `packages/*.md`.
+ * Output is deterministic (LF newlines, trailing newline).
+ */
+export function renderSyncedPackageMarkdown(args: RenderSyncedPackageMarkdownArgs): string {
+	const normalizedSource = normalizeNewlines(args.sourceMarkdown).trimEnd();
+	const header = [
+		"<!--",
+		"  AUTO-GENERATED FILE — DO NOT EDIT DIRECTLY.",
+		`  Generated by: ${args.generatorCommand}`,
+		...args.sources.map((source) => `  Source: ${source}`),
+		"-->",
+		"",
+	].join("\n");
+
+	return `${header}${normalizedSource}\n`;
+}
+
+function normalizeNewlines(input: string): string {
+	return input.replace(/\r\n/g, "\n");
+}
+
+export type SyncPackagesOptions = Readonly<{
+	/** Absolute repo root directory. Defaults to `process.cwd()`. */
+	repoRootDir?: string;
+	/** Doc file loader. Defaults to the remote (GitHub raw) loader. */
+	loader?: DocFileLoader;
+	/** Write a file (absolute path). Defaults to `fs/promises.writeFile`. */
+	writeFile?: (absolutePath: string, content: string) => Promise<void>;
+	/** Ensure a directory exists (absolute path). */
+	mkdirp?: (absoluteDir: string) => Promise<void>;
+	/** Which targets to sync. Defaults to `SYNC_TARGETS`. */
+	targets?: ReadonlyArray<SyncTarget>;
+	/**
+	 * If true, throw when a package's mandatory index.md is missing or a
+	 * source errors. If false, log and continue. Defaults to false.
+	 */
+	strict?: boolean;
+}>;
+
+/** Sync all package docs into `packages/`. */
+export async function syncPackages(options: SyncPackagesOptions = {}): Promise<void> {
+	const repoRootDir = options.repoRootDir ?? process.cwd();
+	const targets = options.targets ?? SYNC_TARGETS;
+	const strict = options.strict ?? false;
+	const loader = options.loader ?? createRemoteLoader();
+
+	const defaultMkdirp = async (absoluteDir: string) => {
+		await mkdir(absoluteDir, { recursive: true });
+	};
+	const mkdirp = options.mkdirp ?? (options.writeFile ? undefined : defaultMkdirp);
+	const writer =
+		options.writeFile ??
+		(async (absolutePath: string, content: string) => {
+			await writeFile(absolutePath, content, "utf-8");
+		});
+
+	for (const target of targets) {
+		let composed: { sources: string[]; markdown: string } | null;
+		try {
+			composed = await composePackageDocs(target.repo, loader);
+		} catch (error) {
+			if (strict) throw error;
+			console.warn(
+				`⚠️  Skipping "${target.repo}" (source error): ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+			continue;
+		}
+
+		if (composed === null) {
+			const message = `Package "${target.repo}" is missing mandatory docs/index.md (${loader.describeSource(target.repo, "index.md")})`;
+			if (strict) throw new Error(message);
+			console.warn(`⚠️  Skipping "${target.repo}": ${message}`);
+			continue;
+		}
+
+		const outputMarkdown = renderSyncedPackageMarkdown({
+			generatorCommand: "bun run sync:packages",
+			sources: composed.sources,
+			sourceMarkdown: composed.markdown,
+		});
+
+		const outputPath = join(repoRootDir, "packages", target.outputFileName);
+		if (mkdirp) {
+			await mkdirp(dirname(outputPath));
+		}
+		await writer(outputPath, outputMarkdown);
+	}
+}
+
+/** Parse CLI args: `--local [root]` selects the local loader. */
+export function loaderFromArgv(argv: ReadonlyArray<string>, cwd: string): DocFileLoader {
+	const localIndex = argv.indexOf("--local");
+	if (localIndex === -1) return createRemoteLoader();
+	const next = argv[localIndex + 1];
+	const root = next && !next.startsWith("--") ? next : join(cwd, "..", "packages");
+	return createLocalLoader(resolve(cwd, root));
+}
+
+if (import.meta.main) {
+	await syncPackages({ loader: loaderFromArgv(process.argv.slice(2), process.cwd()) });
+}
+```
+
+Note: `createLocalLoader` and `loaderFromArgv` are included now because they share the file; their tests land in Task 2. Task 1's tests must pass with this code.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test scripts/sync-packages.test.ts`
+Expected: PASS (9 tests).
+
+- [ ] **Step 5: Lint and typecheck**
+
+Run: `bunx biome check ./scripts && bunx tsc --noEmit`
+Expected: no errors. (If `tsconfig.json` is absent in this repo, skip tsc and note it.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/sync-packages.ts scripts/sync-packages.test.ts
+git commit -m "feat(sync): compose multi-file package docs via loader abstraction (#45)"
+```
+
+---
+
+### Task 2: Local sync mode tests + CLI wiring
+
+**Files:**
+- Modify: `scripts/sync-packages.ts` (only if tests reveal fixes needed — implementation landed in Task 1)
+- Test: `scripts/sync-packages.test.ts`
+
+**Interfaces:**
+- Consumes from Task 1: `createLocalLoader(packagesRootDir, readFileImpl?)`, `loaderFromArgv(argv, cwd)`.
+- Produces: verified CLI behaviour `bun run sync:packages --local [root]`.
+
+- [ ] **Step 1: Append failing/verifying tests for the local loader and argv parsing**
+
+Append to `scripts/sync-packages.test.ts` (inside the file, after the existing describe block):
+
+```typescript
+import { createLocalLoader, loaderFromArgv } from "./sync-packages";
+
+describe("documentation sync: local mode", () => {
+	test("createLocalLoader() reads <root>/<repo>/docs/<file> and nulls ENOENT", async () => {
+		const reads: string[] = [];
+		const loader = createLocalLoader("/ws/packages", async (path) => {
+			reads.push(path);
+			if (path === "/ws/packages/core/docs/index.md") return "# @bunary/core\n";
+			const err = new Error("not found") as NodeJS.ErrnoException;
+			err.code = "ENOENT";
+			throw err;
+		});
+		expect(await loader.loadFile("core", "index.md")).toBe("# @bunary/core\n");
+		expect(await loader.loadFile("core", "quickstart.md")).toBeNull();
+		expect(reads).toContain("/ws/packages/core/docs/quickstart.md");
+		expect(loader.describeSource("core", "index.md")).toBe("/ws/packages/core/docs/index.md");
+	});
+
+	test("createLocalLoader() rethrows non-ENOENT errors", async () => {
+		const loader = createLocalLoader("/ws/packages", async () => {
+			const err = new Error("permission denied") as NodeJS.ErrnoException;
+			err.code = "EACCES";
+			throw err;
+		});
+		expect(loader.loadFile("core", "index.md")).rejects.toThrow(/permission denied/);
+	});
+
+	test("loaderFromArgv() defaults to remote", () => {
+		const loader = loaderFromArgv([], "/docs-repo");
+		expect(loader.describeSource("core", "index.md")).toStartWith("https://raw.githubusercontent.com/");
+	});
+
+	test("loaderFromArgv() with bare --local uses ../packages relative to cwd", () => {
+		const loader = loaderFromArgv(["--local"], "/ws/documentation");
+		expect(loader.describeSource("core", "index.md")).toBe("/ws/packages/core/docs/index.md");
+	});
+
+	test("loaderFromArgv() with --local <root> uses the given root", () => {
+		const loader = loaderFromArgv(["--local", "/elsewhere/pkgs"], "/ws/documentation");
+		expect(loader.describeSource("core", "index.md")).toBe("/elsewhere/pkgs/core/docs/index.md");
+	});
+});
+```
+
+Move the `import { createLocalLoader, loaderFromArgv } from "./sync-packages";` line up into the existing import statement at the top of the file (single combined import) — Biome will flag a mid-file import.
+
+- [ ] **Step 2: Run tests**
+
+Run: `bun test scripts/sync-packages.test.ts`
+Expected: PASS (14 tests). If any fail, fix `scripts/sync-packages.ts` minimally until green.
+
+- [ ] **Step 3: Smoke-test the real CLI in local mode**
+
+Run: `bun run scripts/sync-packages.ts --local ../../../packages && git diff --stat packages/`
+(Path note: from the worktree, the workspace packages dir is `../../../packages` — worktree → documentation → BunaryDev.)
+Expected: script completes; `packages/*.md` headers now show local paths as sources. **Then restore:** `git checkout -- packages/` (committed output must stay remote-generated so the CI drift check passes).
+
+- [ ] **Step 4: Lint**
+
+Run: `bunx biome check ./scripts`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/sync-packages.test.ts scripts/sync-packages.ts
+git commit -m "feat(sync): add --local mode reading sibling package checkouts (#45)"
+```
+
+---
+
+### Task 3: sync-site — testable refactor + frontmatter `order`
+
+**Files:**
+- Modify: `scripts/sync-site.ts`
+- Test: `scripts/sync-site.test.ts` (create)
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces:
+  - `DocMetadata` gains `order?: number`
+  - exported `parseFrontmatter(content: string, fallbackName?: string): { metadata: DocMetadata; body: string }`
+  - exported `generateIndexContent(files: ProcessedFile[], outputDir: string): string` where `ProcessedFile` gains `order?: number`
+  - `if (import.meta.main)` guard so importing the module in tests does not run the build
+
+- [ ] **Step 1: Write failing tests**
+
+Create `scripts/sync-site.test.ts`:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { generateIndexContent, parseFrontmatter, type ProcessedFile } from "./sync-site";
+
+describe("sync-site: frontmatter", () => {
+	test("parses title, description, and order", () => {
+		const { metadata, body } = parseFrontmatter(
+			"---\ntitle: Routing\ndescription: How routes work\norder: 3\n---\n# Routing\n\nBody\n",
+		);
+		expect(metadata.title).toBe("Routing");
+		expect(metadata.description).toBe("How routes work");
+		expect(metadata.order).toBe(3);
+		expect(body).toContain("# Routing");
+	});
+
+	test("no frontmatter keeps heading-derived behaviour and undefined order", () => {
+		const { metadata } = parseFrontmatter("# My Title\n\nFirst paragraph here.\n\n## More\n");
+		expect(metadata.title).toBe("My Title");
+		expect(metadata.description).toBe("First paragraph here.");
+		expect(metadata.order).toBeUndefined();
+	});
+
+	test("non-numeric order is ignored", () => {
+		const { metadata } = parseFrontmatter("---\ntitle: X\norder: soon\n---\nBody\n");
+		expect(metadata.order).toBeUndefined();
+	});
+});
+
+describe("sync-site: index generation", () => {
+	const file = (over: Partial<ProcessedFile>): ProcessedFile => ({
+		componentName: "X",
+		exportName: "X",
+		filePath: "/out/X.tsx",
+		isPackage: false,
+		...over,
+	});
+
+	test("guides sort by order first, then name; unordered files sink to the end", () => {
+		const content = generateIndexContent(
+			[
+				file({ componentName: "Zebra", exportName: "Zebra", filePath: "/out/Zebra.tsx", order: 1 }),
+				file({ componentName: "Alpha", exportName: "Alpha", filePath: "/out/Alpha.tsx" }),
+				file({ componentName: "Mid", exportName: "Mid", filePath: "/out/Mid.tsx", order: 2 }),
+			],
+			"/out",
+		);
+		const zebra = content.indexOf("Zebra");
+		const mid = content.indexOf("Mid");
+		const alpha = content.indexOf("Alpha");
+		expect(zebra).toBeLessThan(mid);
+		expect(mid).toBeLessThan(alpha);
+	});
+
+	test("packages are exported after guides", () => {
+		const content = generateIndexContent(
+			[
+				file({ componentName: "CorePackage", exportName: "CorePackage", filePath: "/out/packages/Core.tsx", isPackage: true }),
+				file({ componentName: "Guide", exportName: "Guide", filePath: "/out/Guide.tsx" }),
+			],
+			"/out",
+		);
+		expect(content.indexOf("Guide")).toBeLessThan(content.indexOf("CorePackage"));
+		expect(content).toContain('from "./packages/Core.js"');
+		expect(content).toContain('export { default as DocsLayout } from "./DocsLayout.js";');
+	});
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test scripts/sync-site.test.ts`
+Expected: FAIL — but watch the failure mode: today `sync-site.ts` calls `build()` at module top level, so the *import itself* will try to run a site build. This confirms why the `import.meta.main` guard is required.
+
+- [ ] **Step 3: Refactor sync-site.ts**
+
+Apply these exact changes to `scripts/sync-site.ts`:
+
+(a) Extend the interface and export it, plus export `ProcessedFile`:
+
+```typescript
+export interface DocMetadata {
+	title: string;
+	description: string;
+	order?: number;
+}
+
+export interface ProcessedFile {
+	componentName: string;
+	exportName: string;
+	filePath: string;
+	isPackage: boolean;
+	order?: number;
+}
+```
+
+(b) Export `parseFrontmatter` and parse `order` (replace the existing function; note the added `order` handling — the no-frontmatter branch is unchanged apart from the signature):
+
+```typescript
+export function parseFrontmatter(content: string): { metadata: DocMetadata; body: string } {
+	const frontmatterRegex = /^---\n([\s\S]*?)\n---\n([\s\S]*)$/;
+	const match = content.match(frontmatterRegex);
+
+	if (!match) {
+		const h1Match = content.match(/^#\s+(.+)$/m);
+		const title = h1Match ? h1Match[1].trim() : basename(content, ".md");
+		const afterH1 = content.replace(/^#\s+.*?\n+/, "").trim();
+		const pMatch = afterH1.match(/^([^\n]+?)(?:\n\n|\n##|$)/);
+		const description = pMatch ? pMatch[1].trim() : "";
+		return { metadata: { title, description }, body: content };
+	}
+
+	const frontmatter = match[1];
+	const body = match[2];
+	const metadata: DocMetadata = { title: "", description: "" };
+	for (const line of frontmatter.split("\n")) {
+		const m = line.match(/^(\w+):\s*(.+)$/);
+		if (m) {
+			const [, key, value] = m;
+			const clean = value.replace(/^["']|["']$/g, "");
+			if (key === "title") metadata.title = clean;
+			if (key === "description") metadata.description = clean;
+			if (key === "order") {
+				const parsed = Number(clean);
+				if (Number.isFinite(parsed)) metadata.order = parsed;
+			}
+		}
+	}
+	return { metadata, body };
+}
+```
+
+(c) In `processMarkdownFile`, thread order into the record — change the `processedFiles.push` line to:
+
+```typescript
+	processedFiles.push({ componentName, exportName, filePath: outputPath, isPackage, order: metadata.order });
+```
+
+(d) Extract index generation into a pure exported function and use it (replace `generateIndexFile` with these two):
+
+```typescript
+function byOrderThenName(a: ProcessedFile, b: ProcessedFile): number {
+	const ao = a.order ?? Number.MAX_SAFE_INTEGER;
+	const bo = b.order ?? Number.MAX_SAFE_INTEGER;
+	if (ao !== bo) return ao - bo;
+	return a.componentName.localeCompare(b.componentName);
+}
+
+export function generateIndexContent(files: ProcessedFile[], outputDir: string): string {
+	const guides = files.filter((f) => !f.isPackage).sort(byOrderThenName);
+	const packages = files.filter((f) => f.isPackage).sort(byOrderThenName);
+	const exports: string[] = [];
+	for (const file of guides) {
+		const rel = relative(outputDir, file.filePath).replace(/\\/g, "/");
+		const importPath = rel.replace(/\.tsx$/, ".js");
+		exports.push(`export { default as ${file.exportName} } from "./${importPath}";`);
+	}
+	if (packages.length > 0) {
+		exports.push("");
+		for (const file of packages) {
+			exports.push(`export { default as ${file.exportName} } from "./packages/${basename(file.filePath, ".tsx")}.js";`);
+		}
+	}
+	return `/**
+ * Documentation pages - auto-generated. Do not edit directly.
+ */
+
+export { default as DocsLayout } from "./DocsLayout.js";
+
+${exports.join("\n")}
+`;
+}
+
+async function generateIndexFile(): Promise<void> {
+	await writeFile(join(OUTPUT_DIR, "index.ts"), generateIndexContent(processedFiles, OUTPUT_DIR), "utf-8");
+	console.log("✓ Generated index.ts");
+}
+```
+
+(e) Guard the entrypoint — replace the trailing `build().catch(...)` call with:
+
+```typescript
+if (import.meta.main) {
+	build().catch((err) => {
+		console.error("❌ Build failed:", err);
+		process.exit(1);
+	});
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test scripts/sync-site.test.ts`
+Expected: PASS (5 tests), and importing the module must NOT trigger a build (no "📚 Building docs" output).
+
+- [ ] **Step 5: Run the real site build to prove no regression**
+
+Run: `DOCS_SITE_OUTPUT=/home/paul/Projects/OpenSource/BunaryDev/site/src/pages/docs bun run sync:site && git -C ../../../site status --short src/pages/docs | head -20`
+(The env override is required: run from the worktree, the default `../site` would resolve to `.worktrees/site`.)
+Expected: build completes; site repo diff limited to regenerated content (no structural surprises). Do not commit the site repo in this task.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+bunx biome check ./scripts
+git add scripts/sync-site.ts scripts/sync-site.test.ts
+git commit -m "feat(site-build): frontmatter order + testable refactor of sync-site (#45)"
+```
+
+---
+
+### Task 4: Frontmatter pass on guides
+
+**Files:**
+- Modify: every `guides/**/*.md` (17 files: `introduction.md`, `philosophy.md`, `getting-started/{index,configuration,structure,examples}.md`, `basics/{index,requests,responses}.md`, `routing/{index,route-parameters,route-groups,named-routes}.md`, `orm/{index,models,query-builder,database-config}.md` — verify the exact list with `find guides -name '*.md'` — plus `security/{index,guards}.md`)
+
+**Interfaces:**
+- Consumes from Task 3: the `title` / `description` / `order` frontmatter schema.
+- Produces: guides carrying explicit frontmatter; sidebar order becomes deliberate.
+
+- [ ] **Step 1: Add frontmatter to each guide**
+
+For each file, add a frontmatter block at the very top preserving the current H1 as `title` and the current first paragraph as `description` (or write a better one-sentence description if the first paragraph is unsuitable). Assign `order` per section to match the reading order the docs README implies:
+
+- `introduction.md` → order 1; `philosophy.md` → order 2
+- `getting-started/`: index 1, configuration 2, structure 3, examples 4
+- `basics/`: index 1, requests 2, responses 3
+- `routing/`: index 1, route-parameters 2, route-groups 3, named-routes 4
+- `orm/`: index 1, models 2, query-builder 3, database-config 4
+- `security/`: index 1, guards 2
+
+Pattern (example for `guides/routing/route-parameters.md`, keeping the existing body untouched below the block):
+
+```markdown
+---
+title: Route Parameters
+description: Capture dynamic URL segments and pass them to handlers.
+order: 2
+---
+# Route Parameters
+...existing content...
+```
+
+- [ ] **Step 2: Rebuild the site and eyeball the export order**
+
+Run: `DOCS_SITE_OUTPUT=/home/paul/Projects/OpenSource/BunaryDev/site/src/pages/docs bun run sync:site && head -40 ../../../site/src/pages/docs/index.ts`
+Expected: exports within each section follow the assigned `order` values, not alphabetical order.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add guides
+git commit -m "docs(guides): add title/description/order frontmatter to all guides (#45)"
+```
+
+---
+
+### Task 5: The bunary-docs skill
+
+**Files:**
+- Create: `.claude/skills/bunary-docs/SKILL.md`
+
+**Interfaces:**
+- Consumes: the commands and conventions delivered by Tasks 1–4.
+- Produces: the skill file (mirrored to the workspace root in Task 7).
+
+- [ ] **Step 1: Write the skill**
+
+Create `.claude/skills/bunary-docs/SKILL.md`:
+
+```markdown
+---
+name: bunary-docs
+description: Use when writing, editing, syncing, reviewing, or auditing Bunary documentation — package docs, guides, or the docs site build — or when a Bunary package API change needs a doc update.
+---
+
+# Bunary documentation workflow
+
+Bunary docs flow through two hops:
+package repo `docs/` → (sync:packages) → `documentation/packages/*.md` → (sync:site) → `site/src/pages/docs/*.tsx`.
+
+## Where to edit — decision table
+
+| You changed / need | Edit here | Never |
+|---|---|---|
+| Package API, feature, CLI command | `packages/{pkg}/docs/index.md` (+ optional `quickstart.md`, `api.md`, `migration.md`) in that package repo | `documentation/packages/*.md` (synced output) |
+| Cross-package tutorial, concepts, getting started | `documentation/guides/**/*.md` | duplicating package API detail in guides |
+| Site chrome, layout, docs shell | `site/` repo (`DocsLayout.tsx` survives rebuilds) | generated `site/src/pages/docs/**` pages |
+
+## Pipeline commands (run from the documentation repo root)
+
+- `bun run sync:packages` — fetch package docs from GitHub main, compose per contract order (`index.md` + `quickstart.md` + `api.md` + `migration.md`), write `packages/*.md`.
+- `bun run scripts/sync-packages.ts --local [root]` — same, but read from local sibling checkouts (default root `../packages`); use to preview unpushed package-doc changes. Never commit locally-sourced `packages/*.md` — committed output must come from the remote sync.
+- `bun run sync:site` — convert guides + packages markdown to React components in the site repo.
+- CI drift check: a PR here must include the `packages/*.md` produced by `bun run sync:packages`, or CI fails.
+
+## Authoring conventions
+
+- Frontmatter on guides: `title`, `description`, `order` (sidebar position within its section). Package docs: optional.
+- `docs/index.md` starts with `# @bunary/{pkg}`.
+- Install snippets show only the one package (`bun add @bunary/http`); dependencies arrive transitively.
+- Example-driven; code fences carry a language (```typescript).
+- A feature PR in a package repo is not done until `docs/` reflects the change; the docs sync PR follows here.
+
+## Drift audit (when asked to review docs)
+
+1. Per package (core, http, auth, orm, cli): compare `docs/index.md` claims against the package's actual exports and JSDoc; fix gaps in the package repo, then sync.
+2. Per guide section (`getting-started/`, `basics/`, `routing/`, `orm/`, `security/`): confirm examples and APIs still match the packages.
+3. Run `bun run sync:packages` and commit any drift.
+4. Details: `DOCS_REVIEW.md`, `PACKAGE_DOCS_CONTRACT.md`, `PUBLISH_WORKFLOW.md` in the documentation repo — those are the source of truth; this skill is the operational summary.
+```
+
+- [ ] **Step 2: Sanity-check the skill against reality**
+
+Run: `bun run scripts/sync-packages.ts --local ../../../packages` (should succeed) and confirm every command named in the skill exists in `package.json` scripts. Restore any modified `packages/*.md` with `git checkout -- packages/`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/bunary-docs/SKILL.md
+git commit -m "docs: add bunary-docs skill capturing the documentation workflow (#45)"
+```
+
+---
+
+### Task 6: Update the process docs
+
+**Files:**
+- Modify: `README.md`, `PACKAGE_DOCS_CONTRACT.md`, `PUBLISH_WORKFLOW.md`
+
+**Interfaces:**
+- Consumes: behaviour shipped in Tasks 1–3.
+- Produces: human-facing docs matching the new pipeline.
+
+- [ ] **Step 1: README.md**
+
+In the Commands table, update the `sync:packages` row description to: "Fetch package docs (index + quickstart + api + migration when present) from GitHub and write `packages/*.md`. Add `--local [root]` to read from local sibling checkouts for preview." Add a sentence under "sync:packages" documenting local mode with the example `bun run scripts/sync-packages.ts --local`. Mention the frontmatter schema (`title`, `description`, `order`) under "Writing Documentation → Guides".
+
+- [ ] **Step 2: PACKAGE_DOCS_CONTRACT.md**
+
+Change the phase-2 section heading from "Follow-up mapping (phase 2, optional)" to "Composition (phase 2 — implemented)" and state: the sync now concatenates `index.md` + `quickstart.md` + `api.md` + `migration.md` when present; only `index.md` is mandatory. Update the MVP mapping table note accordingly (source column becomes "docs/*.md composed").
+
+- [ ] **Step 3: PUBLISH_WORKFLOW.md**
+
+Add one paragraph after "How to sync": "To preview package-doc changes before pushing, run `bun run scripts/sync-packages.ts --local` — it reads the local sibling checkouts instead of GitHub main. Do not commit locally-sourced output; the committed `packages/*.md` must come from the default remote sync."
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md PACKAGE_DOCS_CONTRACT.md PUBLISH_WORKFLOW.md
+git commit -m "docs: document --local sync mode, phase-2 composition, frontmatter schema (#45)"
+```
+
+---
+
+### Task 7: Workspace-root consolidation (outside the git repo)
+
+**Files:**
+- Delete: `/home/paul/Projects/OpenSource/BunaryDev/scripts/build-docs.ts`
+- Modify: `/home/paul/Projects/OpenSource/BunaryDev/CLAUDE.md`
+- Create: `/home/paul/Projects/OpenSource/BunaryDev/.claude/skills/bunary-docs/SKILL.md` (copy)
+- Check: `/home/paul/Projects/OpenSource/BunaryDev/package.json` for a docs script referencing build-docs.ts
+
+**Interfaces:**
+- Consumes from Task 5: the skill file to mirror.
+- Produces: one converter, workspace-level skill availability.
+
+These files are NOT under version control (the workspace root is not a git repo) — plain local edits, no branch/commit for this task.
+
+- [ ] **Step 1: Check for references to build-docs.ts**
+
+Run: `grep -rn "build-docs" /home/paul/Projects/OpenSource/BunaryDev --include='*.json' --include='*.md' -l | grep -v node_modules | grep -v .worktrees`
+Expected: `CLAUDE.md`, possibly root `package.json`. Update every hit in the next steps.
+
+- [ ] **Step 2: Delete the legacy converter**
+
+Run: `rm /home/paul/Projects/OpenSource/BunaryDev/scripts/build-docs.ts`
+
+- [ ] **Step 3: Update root CLAUDE.md**
+
+Replace the "Documentation build" block:
+
+````markdown
+Documentation build (source of truth: the `documentation/` repo; converts guides + package docs markdown → React components in `site/src/pages/docs/`):
+```bash
+cd documentation && bun run sync:site
+# preview local package-doc edits first: bun run scripts/sync-packages.ts --local
+```
+````
+
+If root `package.json` has a script invoking `scripts/build-docs.ts`, repoint it to `cd documentation && bun run sync:site` or delete the script entry.
+
+- [ ] **Step 4: Mirror the skill to the workspace root**
+
+Run: `mkdir -p /home/paul/Projects/OpenSource/BunaryDev/.claude/skills/bunary-docs && cp /home/paul/Projects/OpenSource/BunaryDev/documentation/.worktrees/45-docs-process-v2/.claude/skills/bunary-docs/SKILL.md /home/paul/Projects/OpenSource/BunaryDev/.claude/skills/bunary-docs/SKILL.md`
+
+- [ ] **Step 5: Verify nothing still imports the deleted script**
+
+Run: `grep -rn "build-docs" /home/paul/Projects/OpenSource/BunaryDev --include='*.ts' --include='*.json' --include='*.md' -l | grep -v node_modules | grep -v .worktrees`
+Expected: no output.
+
+---
+
+### Task 8: Full verification + PR
+
+**Files:**
+- None new.
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: green suite, open PR closing #45.
+
+- [ ] **Step 1: Full test suite in the documentation repo**
+
+Run: `bun test`
+Expected: all tests pass — report the exact count (Tasks 1–3 target 19 tests in scripts/ plus any pre-existing ones).
+
+- [ ] **Step 2: Full pipeline end-to-end**
+
+Run: `DOCS_SITE_OUTPUT=/home/paul/Projects/OpenSource/BunaryDev/site/src/pages/docs bun run sync && git status --short`
+(Env override needed for the sync:site half — from the worktree the default output path would resolve to `.worktrees/site`.)
+Expected: pipeline completes (remote mode); any resulting `packages/*.md` drift is legitimate remote drift — commit it if present:
+
+```bash
+git add packages && git commit -m "chore(sync): refresh packages/*.md from package repos (#45)"
+```
+
+- [ ] **Step 3: Lint everything changed**
+
+Run: `bunx biome check ./scripts`
+Expected: clean.
+
+- [ ] **Step 4: Push and open the PR**
+
+```bash
+git push -u origin docs/45-docs-process-v2
+gh pr create --title "feat: documentation process v2 — composition, --local mode, frontmatter, bunary-docs skill" --body "Closes #45.
+
+- Multi-file package-doc composition (contract phase 2): index + quickstart + api + migration
+- --local sync mode reading sibling package checkouts for preview
+- Frontmatter standard (title/description/order) driving site export order
+- sync-site refactored into testable exported functions with import.meta.main guard
+- bunary-docs Claude skill (.claude/skills/) capturing the workflow
+- Process docs (README, CONTRACT, PUBLISH_WORKFLOW) updated
+
+Spec: docs/superpowers/specs/2026-07-06-docs-process-v2-design.md
+Tests: full suite green (report count from CI)."
+```
+
+Expected: PR URL printed. Do not merge — merging requires Paul's explicit approval.

--- a/docs/superpowers/specs/2026-07-06-docs-process-v2-design.md
+++ b/docs/superpowers/specs/2026-07-06-docs-process-v2-design.md
@@ -1,0 +1,112 @@
+# Documentation process v2 — design
+
+**Date:** 2026-07-06
+**Issue:** bunary-dev/documentation#45
+**Status:** Approved
+
+## Context
+
+The Bunary documentation pipeline is a two-hop flow: package repos
+(`bunary-dev/{core,http,auth,orm,cli}`) author reference docs in `docs/index.md`;
+`bun run sync:packages` fetches them from GitHub main into `packages/*.md` in this
+repo; `bun run sync:site` converts `guides/` + `packages/` markdown into React
+components in the site repo (`site/src/pages/docs/`). A CI drift check fails PRs
+when `packages/*.md` is stale.
+
+Pain points this design addresses:
+
+- **Docs drift from code** — nothing prompts a doc update when a package API changes.
+- **Sync/build friction** — sync only reads from GitHub main, so local doc edits
+  cannot be previewed before pushing; and there are two divergent md→React
+  converters (workspace-root `scripts/build-docs.ts` vs this repo's
+  `scripts/sync-site.ts`).
+- **Authoring inconsistency** — conventions live across four markdown files
+  (`README.md`, `PACKAGE_DOCS_CONTRACT.md`, `PUBLISH_WORKFLOW.md`,
+  `DOCS_REVIEW.md`) with nothing enforcing them during a coding session.
+
+## 1. `bunary-docs` skill
+
+One Claude Code skill covering the whole documentation loop. Versioned in this
+repo at `.claude/skills/bunary-docs/SKILL.md` and mirrored (copy) to the
+BunaryDev workspace root `.claude/skills/` so it loads for sessions started at
+the workspace root (the root is not a git repo, hence the mirror).
+
+Contents:
+
+- **Where-to-edit decision table** — package API/feature change → edit
+  `docs/` in that package repo, never `packages/*.md` here; cross-package
+  tutorial → `guides/` here; site chrome → site repo.
+- **Pipeline commands** — `sync:packages` (remote default, `--local` for
+  preview), `sync:site`, and the CI expectation that synced `packages/*.md`
+  land in the same PR as the doc source change.
+- **Authoring conventions** — frontmatter schema, top-heading rule,
+  single-package install snippet rule, example-driven style, docs PR
+  accompanies feature PR.
+- **Drift-audit procedure** — distilled from `DOCS_REVIEW.md`: per package,
+  compare `docs/index.md` claims against actual exports/JSDoc; audit each
+  guide section (`getting-started/`, `basics/`, `routing/`, `orm/`,
+  `security/`) against current APIs.
+
+The four markdown process docs remain the human-facing source of truth; the
+skill links to them instead of duplicating their content.
+
+## 2. Converter consolidation
+
+`scripts/sync-site.ts` (this repo) becomes the only markdown→React converter.
+The legacy workspace-root `scripts/build-docs.ts` is deleted and the workspace
+root `CLAUDE.md` documentation-build section is updated to
+`cd documentation && bun run sync:site`. (Workspace-root files are not under
+version control; that part is a plain local edit outside this repo.)
+
+## 3. Local sync mode
+
+`scripts/sync-packages.ts` gains `--local [root]`:
+
+- `--local` reads `packages/{pkg}/docs/*.md` from the local sibling checkouts;
+  root defaults to `../packages` relative to this repo.
+- Remote GitHub-main fetch remains the default; CI drift-check semantics are
+  unchanged.
+- Missing local `docs/index.md` → hard fail naming the package (parity with a
+  remote 404 today).
+
+## 4. Multi-file composition (contract phase 2)
+
+Both modes compose per-package pages in the contract's order:
+`index.md` + `quickstart.md` + `api.md` + `migration.md` → one
+`packages/{pkg}.md`. Only `index.md` is mandatory; a 404/ENOENT on the others
+skips that file. Single-file packages keep working unchanged; packages adopt
+the split gradually. `PACKAGE_DOCS_CONTRACT.md` is updated to mark phase 2 as
+implemented.
+
+## 5. Frontmatter standard
+
+Schema: `title`, `description`, `order` (sidebar position). `sync-site.ts`
+uses frontmatter for page metadata and sidebar ordering. Files without
+frontmatter keep the current derived-from-heading behaviour, so adoption is
+opt-in and non-breaking. Existing guides get frontmatter added as a mechanical
+pass in this repo.
+
+## Testing
+
+TDD throughout:
+
+- Extend `scripts/sync-packages.test.ts`: local mode resolution, composition
+  order, skip-missing-optional-files, hard-fail on missing `index.md`.
+- Add `scripts/sync-site.test.ts`: frontmatter parsing, sidebar ordering,
+  heading-derived fallback, output cleaning.
+
+Full suite green before the PR.
+
+## Delivery
+
+- One PR in this repo (branch `docs/45-docs-process-v2`, closes #45):
+  sections 1 (skill), 3, 4, 5, plus contract/README updates.
+- Local-only edits at the workspace root: section 2 cleanup and the skill
+  mirror.
+
+## Out of scope
+
+- Repositioning the framework's "inspired by Laravel" messaging (discussed and
+  deferred; recommendation was "Laravel-inspired DX, Symfony-style standalone
+  packages" if ever revisited).
+- Automating sync via CI beyond the existing drift check.

--- a/guides/basics/index.md
+++ b/guides/basics/index.md
@@ -1,3 +1,8 @@
+---
+title: Middleware
+description: Intercept and modify requests and responses.
+order: 1
+---
 
 # Middleware
 

--- a/guides/basics/requests.md
+++ b/guides/basics/requests.md
@@ -1,3 +1,8 @@
+---
+title: Requests
+description: Accessing and working with incoming HTTP requests.
+order: 2
+---
 
 # Requests
 

--- a/guides/basics/responses.md
+++ b/guides/basics/responses.md
@@ -1,3 +1,8 @@
+---
+title: Responses
+description: Sending HTTP responses from your handlers.
+order: 3
+---
 
 # Responses
 

--- a/guides/getting-started/configuration.md
+++ b/guides/getting-started/configuration.md
@@ -1,3 +1,8 @@
+---
+title: Configuration
+description: Understanding and customizing your Bunary application configuration.
+order: 2
+---
 
 # Configuration
 

--- a/guides/getting-started/examples.md
+++ b/guides/getting-started/examples.md
@@ -1,3 +1,9 @@
+---
+title: Examples
+description: Explore complete working examples to see Bunary in action.
+order: 4
+---
+
 # Examples
 
 Explore complete working examples to see Bunary in action. All examples are available in the [bunary-dev/examples](https://github.com/bunary-dev/examples) repository.

--- a/guides/getting-started/index.md
+++ b/guides/getting-started/index.md
@@ -1,3 +1,8 @@
+---
+title: Installation
+description: Get Bunary up and running in your project.
+order: 1
+---
 
 # Installation
 

--- a/guides/getting-started/structure.md
+++ b/guides/getting-started/structure.md
@@ -1,3 +1,8 @@
+---
+title: Directory Structure
+description: Understanding the default Bunary project layout.
+order: 3
+---
 
 # Directory Structure
 

--- a/guides/introduction.md
+++ b/guides/introduction.md
@@ -1,3 +1,8 @@
+---
+title: Introduction
+description: Bunary is a Bun-first backend platform inspired by Laravel, focused on expressive developer experience, fast startup, and minimal operational overhead.
+order: 1
+---
 
 # Introduction
 

--- a/guides/orm/database-config.md
+++ b/guides/orm/database-config.md
@@ -1,3 +1,9 @@
+---
+title: Database Configuration
+description: Configure your database connection for the ORM.
+order: 4
+---
+
 # Database Configuration
 
 Configure your database connection for the ORM.

--- a/guides/orm/index.md
+++ b/guides/orm/index.md
@@ -1,3 +1,9 @@
+---
+title: ORM
+description: Working with databases using Bunary's ORM.
+order: 1
+---
+
 # ORM
 
 Working with databases using Bunary's ORM.

--- a/guides/orm/migrations.md
+++ b/guides/orm/migrations.md
@@ -1,3 +1,9 @@
+---
+title: Migrations
+description: Manage database schema changes with migration files and the Schema builder.
+order: 5
+---
+
 # Migrations
 
 Manage database schema changes with migration files and the Schema builder.

--- a/guides/orm/models.md
+++ b/guides/orm/models.md
@@ -1,3 +1,9 @@
+---
+title: Working with Models
+description: Create and configure model classes for your database tables.
+order: 2
+---
+
 # Working with Models
 
 Create and configure model classes for your database tables.

--- a/guides/orm/query-builder.md
+++ b/guides/orm/query-builder.md
@@ -1,3 +1,9 @@
+---
+title: Query Builder
+description: The ORM provides a fluent query builder interface for building database queries.
+order: 3
+---
+
 # Query Builder
 
 The ORM provides a fluent query builder interface for building database queries.

--- a/guides/philosophy.md
+++ b/guides/philosophy.md
@@ -1,3 +1,8 @@
+---
+title: Philosophy
+description: The guiding principles behind Bunary's design decisions.
+order: 2
+---
 
 # Philosophy
 

--- a/guides/routing/index.md
+++ b/guides/routing/index.md
@@ -1,3 +1,9 @@
+---
+title: Routing
+description: Define your application's routes and endpoints.
+order: 1
+---
+
 # Routing
 
 Define your application's routes and endpoints.

--- a/guides/routing/named-routes.md
+++ b/guides/routing/named-routes.md
@@ -1,3 +1,9 @@
+---
+title: Named Routes
+description: Assign names to routes for URL generation, making it easy to generate URLs without hardcoding paths.
+order: 4
+---
+
 # Named Routes
 
 Assign names to routes for URL generation, making it easy to generate URLs without hardcoding paths.

--- a/guides/routing/route-groups.md
+++ b/guides/routing/route-groups.md
@@ -1,3 +1,9 @@
+---
+title: Route Groups
+description: Group routes together with shared prefixes, middleware, and name prefixes for better organization.
+order: 3
+---
+
 # Route Groups
 
 Group routes together with shared prefixes, middleware, and name prefixes for better organization.

--- a/guides/routing/route-parameters.md
+++ b/guides/routing/route-parameters.md
@@ -1,3 +1,9 @@
+---
+title: Route Parameters
+description: Capture dynamic segments of the URL using route parameters.
+order: 2
+---
+
 # Route Parameters
 
 Capture dynamic segments of the URL using route parameters.

--- a/guides/security/guards.md
+++ b/guides/security/guards.md
@@ -1,3 +1,9 @@
+---
+title: Guards
+description: Understanding and using authentication guards with app-scoped auth.
+order: 2
+---
+
 # Guards
 
 Understanding and using authentication guards with app-scoped auth.

--- a/guides/security/index.md
+++ b/guides/security/index.md
@@ -1,3 +1,8 @@
+---
+title: Authentication
+description: Securing your API with the Bunary authentication system.
+order: 1
+---
 
 # Authentication
 

--- a/packages/cli.md
+++ b/packages/cli.md
@@ -43,7 +43,7 @@ bunary init my-app --auth jwt
 bunary init .
 ```
 
-The command creates `package.json`, `bunary.config.ts`, `src/index.ts`, and `src/routes/` (main, groupExample, index). If you used `--auth`, it also creates `src/middleware/basic.ts` or `jwt.ts` and wires it in the entrypoint. Next steps: `cd <name>`, `bun install`, `bun run dev`.
+The command creates `package.json`, `config/bunary.ts`, `src/index.ts`, and `src/routes/` (main, groupExample, index). If you used `--auth`, it also creates `src/middleware/basic.ts` or `jwt.ts` and wires it in the entrypoint. Next steps: `cd <name>`, `bun install`, `bun run dev`.
 
 ### bunary model:make \<table-name\>
 
@@ -71,7 +71,7 @@ What init and the generators produce.
 
 **package.json (default):** dependencies include `@bunary/core` and `@bunary/http`. With `--auth basic` or `--auth jwt`, `@bunary/auth` is added.
 
-**bunary.config.ts:** Uses `defineConfig` from `@bunary/core`. Sets app name, env, debug.
+**config/bunary.ts:** Uses `defineConfig` from `@bunary/core`. Sets app name, env, debug.
 
 **src/index.ts:** Creates the app with `createApp`, calls `registerRoutes(app)`, then `app.listen({ port: 3000 })`. With auth, it also imports the middleware and calls `app.use(basicMiddleware)` or `app.use(jwtMiddleware)`.
 
@@ -116,3 +116,64 @@ InitOptions: `{ auth?: "basic" | "jwt" }`. Pass to `init`, `generatePackageJson`
 ## Requirements
 
 - Bun ≥ 1.0.0
+
+## Custom Project Commands
+
+You can add your own CLI commands to any Bunary project. The CLI picks them up automatically when you run `bunary` from that project directory.
+
+### Where to put them
+
+Create a `src/commands/` directory and export one command per file:
+
+```
+my-app/
+  config/
+    bunary.ts          ← register commands here
+  src/
+    commands/
+      seed.ts          ← your custom command
+      deploy.ts
+    routes/
+    index.ts
+```
+
+### Defining a command
+
+Each command is a plain object with `name`, `description`, and an async `run` function:
+
+```typescript
+// src/commands/seed.ts
+export const seedDatabase = {
+  name: "db:seed",
+  description: "Seed the database with test data",
+  category: "project",
+  run: async () => {
+    console.log("Seeding...");
+    // your logic here
+  },
+};
+```
+
+### Registering commands in config
+
+Add a `commands` array to your config file. The CLI looks for `config/bunary.ts` first, then falls back to `bunary.config.ts`:
+
+```typescript
+// config/bunary.ts
+import { defineConfig } from "@bunary/core";
+import { seedDatabase } from "../src/commands/seed.js";
+import { deploy } from "../src/commands/deploy.js";
+
+export default defineConfig({
+  app: { name: "my-app" },
+  commands: [seedDatabase, deploy],
+});
+```
+
+Now `bunary db:seed` and `bunary deploy` work from your project root. They also show up under a "Project" section in `bunary --help`.
+
+### Rules
+
+- Project commands can't override built-in commands (`init`, `migrate`, etc.). The CLI throws if there's a name collision.
+- Commands missing `name`, `description`, or `run` are silently skipped.
+- If `category` is omitted it defaults to `"project"`.

--- a/packages/core.md
+++ b/packages/core.md
@@ -69,11 +69,14 @@ Returns true if NODE_ENV is "test".
 
 ### defineConfig(config: BunaryConfig): BunaryConfig
 
-Type-safe configuration helper with defaults.
+Type-safe configuration helper with defaults. Validates `app.name` is a non-empty string (throws for non-string values, empty strings, and whitespace-only strings). Passes through any augmented properties (e.g. `orm` from `@bunary/orm`).
 
 ### createConfig(config?: BunaryConfig): BunaryConfigStore
 
-Create an instance-scoped configuration store with `get()`, `set()`, and `clear()`.
+Create an instance-scoped configuration store with `get()`, `set()`, `has()`, and `clear()`.
+
+- `get()` returns a deep-frozen `Readonly<BunaryConfig>` — both the top-level object and all nested objects are immutable.
+- `has()` returns `true` if config has been set and not cleared.
 
 ## Requirements
 

--- a/packages/http.md
+++ b/packages/http.md
@@ -20,6 +20,8 @@ Part of the [Bunary](https://github.com/bunary-dev) ecosystem: a Bun-first backe
 - 🏷️ **Named Routes** - URL generation with route names
 - ✅ **Route Constraints** - Validate parameters with regex patterns
 - ❓ **Optional Parameters** - Flexible routes with optional path segments
+- 🌐 **Wildcard Routes** - Catch-all `/*` and `/**` patterns for SPA fallbacks and proxies
+- 🔀 **CORS** - Built-in CORS middleware with configurable origins, methods, headers, and credentials
 
 ## Installation
 
@@ -74,6 +76,7 @@ apiApp.get('/users', () => ({})); // Matches /api/users
   - Called when a route handler or middleware throws an error
   - Receives `RequestContext` and the error object
   - Can return `Response` or `HandlerResponse`
+  - If not provided, the default handler hides error details in production
 
 **Example with custom error handlers:**
 
@@ -96,6 +99,32 @@ const app = createApp({
 });
 ```
 
+#### Typed Locals
+
+Pass a type parameter to `createApp()` to get type-safe `ctx.locals`:
+
+```typescript
+interface AppLocals {
+  user: { id: number; name: string };
+  requestId: string;
+}
+
+const app = createApp<AppLocals>();
+
+app.use(async (ctx, next) => {
+  ctx.locals.user = await getUser(ctx.request);  // typed
+  ctx.locals.requestId = crypto.randomUUID();     // typed
+  return next();
+});
+
+app.get('/me', (ctx) => ({
+  name: ctx.locals.user.name,       // typed as string
+  requestId: ctx.locals.requestId,  // typed as string
+}));
+```
+
+The generic defaults to `Record<string, unknown>`, so existing code is fully backward-compatible.
+
 ### Route Registration
 
 Register routes using chainable HTTP method helpers:
@@ -104,7 +133,7 @@ Register routes using chainable HTTP method helpers:
 app
   .get('/users', () => ({ users: [] }))
   .post('/users', async (ctx) => {
-    const body = await ctx.request.json();
+    const body = await ctx.json();
     return { id: 1, ...body };
   })
   .put('/users/:id', (ctx) => {
@@ -120,7 +149,7 @@ app
 
 ### Path Parameters
 
-Path parameters are extracted automatically:
+Path parameters are extracted automatically and decoded with `decodeURIComponent`:
 
 ```typescript
 app.get('/users/:id', (ctx) => {
@@ -132,6 +161,58 @@ app.get('/posts/:postId/comments/:commentId', (ctx) => {
   return { postId, commentId };
 });
 ```
+
+#### Typed Parameters
+
+Pass a type parameter to any route method for typed `ctx.params`:
+
+```typescript
+app.get<{ id: string }>('/users/:id', (ctx) => {
+  ctx.params.id;  // string (not string | undefined)
+  return { userId: ctx.params.id };
+});
+
+app.get<{ org: string; repo: string }>('/orgs/:org/repos/:repo', (ctx) => {
+  ctx.params.org;   // string
+  ctx.params.repo;  // string
+  return { org: ctx.params.org, repo: ctx.params.repo };
+});
+
+// Optional params
+app.get<{ format?: string }>('/data/:format?', (ctx) => {
+  return { format: ctx.params.format ?? 'json' };
+});
+```
+
+Values remain strings at runtime — no automatic coercion. The generic only narrows the TypeScript type.
+
+When no type parameter is provided, `ctx.params` defaults to `Record<string, string | undefined>`.
+
+#### URL Encoding and Unicode
+
+Path parameters are automatically decoded from their URL-encoded form:
+
+```typescript
+app.get('/users/:name', (ctx) => {
+  return { name: ctx.params.name };
+});
+
+// GET /users/hello%20world → { name: "hello world" }
+// GET /users/caf%C3%A9     → { name: "café" }
+// GET /users/日本語         → { name: "日本語" }
+```
+
+Encoded slashes (`%2F`) are captured within a single segment and decoded:
+
+```typescript
+app.get('/files/:path', (ctx) => {
+  return { path: ctx.params.path };
+});
+
+// GET /files/dir%2Ffile.txt → { path: "dir/file.txt" }
+```
+
+> **Note:** Route constraints (`.where()`) are checked against the **decoded** parameter value.
 
 ### Query Parameters
 
@@ -157,16 +238,77 @@ app.get('/filter', (ctx) => {
 
 ### Request Context
 
-Route handlers receive a `RequestContext` object:
+Route handlers receive a `RequestContext<TLocals, TParams>` object:
 
 ```typescript
-interface RequestContext {
+interface RequestContext<
+  TLocals extends object = Record<string, unknown>,
+  TParams extends PathParams = PathParams,
+> {
   request: Request;  // Original Bun Request object
-  params: Record<string, string | undefined>;  // Path parameters (optional params may be undefined)
+  params: TParams;   // Path parameters (narrowed by route generic)
   query: URLSearchParams;  // Query parameters (use .get() and .getAll())
-  locals: Record<string, unknown>;  // Per-request storage for middleware and handlers
+  locals: TLocals;   // Per-request storage (narrowed by createApp generic)
+
+  // Body parsing helpers
+  json<T = unknown>(): Promise<T>;     // Parse JSON body (throws BodyParseError)
+  text(): Promise<string>;             // Get body as string
+  formData(): Promise<FormData>;       // Parse form data (throws BodyParseError)
 }
 ```
+
+#### Body Parsing Helpers
+
+`ctx.json()`, `ctx.text()`, and `ctx.formData()` are thin wrappers around the underlying `Request` methods with improved error handling:
+
+```typescript
+// Parse JSON with type inference
+app.post('/users', async (ctx) => {
+  const body = await ctx.json<{ name: string; email: string }>();
+  return { id: 1, name: body.name, email: body.email };
+});
+
+// Get raw text body
+app.post('/webhooks', async (ctx) => {
+  const payload = await ctx.text();
+  return { received: payload.length };
+});
+
+// Parse form data
+app.post('/upload', async (ctx) => {
+  const form = await ctx.formData();
+  const name = form.get('name');
+  return { name };
+});
+```
+
+Malformed bodies throw `BodyParseError`, which you can catch for custom error responses:
+
+```typescript
+import { BodyParseError } from '@bunary/http';
+
+app.post('/users', async (ctx) => {
+  try {
+    return await ctx.json();
+  } catch (error) {
+    if (error instanceof BodyParseError) {
+      return new Response(
+        JSON.stringify({ error: error.message }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+    throw error;
+  }
+});
+```
+
+> The original `ctx.request` is still available for advanced use cases (e.g. streaming, `arrayBuffer()`, `blob()`).
+> Note: per the Fetch API, the request body can only be consumed once. If middleware calls `ctx.json()`, `ctx.text()`, or `ctx.formData()`, the downstream handler cannot read the body again; instead, share the parsed data via `ctx.locals` or work with a cloned request if you need to access the body in multiple places.
+
+`TLocals` is set once via `createApp<TLocals>()` and flows to all handlers and middleware.
+`TParams` is set per-route via `app.get<TParams>()` and only affects that handler's `ctx.params`.
+
+Both default to their untyped forms for full backward compatibility.
 
 ### HTTP Method Handling
 
@@ -330,6 +472,53 @@ app.use(async (ctx, next) => {
 });
 ```
 
+### CORS Middleware
+
+Built-in CORS middleware handles preflight `OPTIONS` requests and adds the appropriate headers to actual responses.
+
+```typescript
+import { createApp, cors } from '@bunary/http';
+
+const app = createApp();
+
+// Allow any origin (default)
+app.use(cors());
+```
+
+#### Configuration
+
+```typescript
+app.use(cors({
+  origin: 'https://myapp.com',             // string, string[], or "*" (default)
+  methods: ['GET', 'POST'],                 // default: GET, HEAD, PUT, POST, DELETE, PATCH
+  allowHeaders: ['Content-Type', 'X-Token'], // default: reflects Access-Control-Request-Headers
+  exposeHeaders: ['X-Request-Id'],          // headers the browser may read from the response
+  credentials: true,                        // include Access-Control-Allow-Credentials
+  maxAge: 86400,                            // preflight cache duration in seconds
+}));
+```
+
+#### Multiple Origins
+
+```typescript
+app.use(cors({
+  origin: ['https://app1.com', 'https://app2.com'],
+  credentials: true,
+}));
+```
+
+When `origin` is a string or array (not `"*"`), a `Vary: Origin` header is included automatically so caches distinguish responses per origin.
+
+#### Per-Group CORS
+
+Apply CORS to specific route groups instead of globally:
+
+```typescript
+app.group({ prefix: '/api', middleware: [cors()] }, (router) => {
+  router.get('/users', () => ({ users: [] }));
+});
+```
+
 ## Route Groups
 
 Group routes together with shared prefixes, middleware, and name prefixes.
@@ -484,12 +673,102 @@ app.get('/archive/:year?/:month?', (ctx) => {
 app.get('/posts/:id?', (ctx) => ({})).whereNumber('id');
 ```
 
-## Error Handling
+## Wildcard Routes
 
-Uncaught errors in handlers return a 500 response. By default the body includes the error message (via the built-in handler). **Security note:** Returning `error.message` in production can leak internal details (e.g. database errors, file paths) to clients. Use a custom `onError` handler in production that returns a generic message to the client while logging the full error server-side, or expose detailed messages only in a trusted debug mode.
+End a route path with `/*` or `/**` to create a catch-all route. The remaining path is captured as `ctx.params["*"]`.
 
 ```typescript
-// Default: 500 with error message. For production, prefer custom onError:
+// SPA fallback — serves index.html for any unmatched path
+app.get('/*', (ctx) => {
+  return new Response(Bun.file('public/index.html'));
+});
+
+// Static file serving (with path traversal protection)
+app.get('/assets/*', (ctx) => {
+  const filePath = ctx.params['*'];
+  if (!filePath) return new Response('Not Found', { status: 404 });
+
+  const resolved = Bun.resolveSync(`public/${filePath}`, process.cwd());
+  const root = Bun.resolveSync('public', process.cwd());
+  if (!resolved.startsWith(root)) {
+    return new Response('Forbidden', { status: 403 });
+  }
+  return new Response(Bun.file(resolved));
+});
+
+// GET /assets/css/style.css → ctx.params["*"] = "css/style.css"
+// GET /assets/js/app.js     → ctx.params["*"] = "js/app.js"
+// GET /assets               → ctx.params["*"] = undefined
+```
+
+`/*` and `/**` behave identically — `/**` is a visual convention to signal deep matching.
+
+### Wildcards with Named Parameters
+
+Combine named parameters and a trailing wildcard:
+
+```typescript
+app.get('/users/:id/*', (ctx) => {
+  const { id } = ctx.params;
+  const remaining = ctx.params['*'];
+  return { id, path: remaining };
+});
+
+// GET /users/42/docs/readme.md → { id: "42", path: "docs/readme.md" }
+```
+
+### Wildcards in Groups
+
+Wildcard routes compose with group prefixes and `basePath`:
+
+```typescript
+app.group('/api', (router) => {
+  router.get('/proxy/*', async (ctx) => {
+    const target = ctx.params['*'];
+    return fetch(`https://backend.example.com/${target}`);
+  });
+});
+
+// GET /api/proxy/v2/users → target = "v2/users"
+```
+
+### Route Priority
+
+Routes match in registration order (first match wins). Register specific routes before wildcard catch-alls:
+
+```typescript
+app.get('/assets/manifest.json', (ctx) => ({ type: 'manifest' }));
+app.get('/assets/*', (ctx) => {
+  return new Response(Bun.file(`public/${ctx.params['*']}`));
+});
+
+// GET /assets/manifest.json → hits the specific route
+// GET /assets/style.css     → hits the wildcard
+```
+
+### Wildcard URL Generation
+
+Named wildcard routes support URL generation via `app.route()`. Pass the `"*"` param for the remaining path:
+
+```typescript
+app.get('/assets/*', () => ({})).name('assets');
+
+app.route('assets', { '*': 'css/style.css' }); // → "/assets/css/style.css"
+app.route('assets');                            // → "/assets"
+```
+
+> **Note:** The wildcard must appear at the end of the path. A `*` in the middle of a path (e.g., `/*/foo`) throws an error.
+
+## Error Handling
+
+Uncaught errors in handlers return a 500 response. The default error handler is environment-aware:
+
+- **Production** (`NODE_ENV=production`): Returns a generic `"Internal Server Error"` message to avoid leaking sensitive details like database errors, file paths, or stack traces.
+- **Development/Test** (any other `NODE_ENV`): Returns the full `error.message` for easier debugging.
+
+For full control, use a custom `onError` handler:
+
+```typescript
 createApp({
   onError: (ctx, error) => {
     console.error('Request error:', error);
@@ -513,7 +792,8 @@ import type {
   GroupOptions,
   GroupRouter,
   GroupCallback,
-  RouteInfo
+  RouteInfo,
+  CorsOptions,
 } from '@bunary/http';
 ```
 

--- a/scripts/sync-packages.test.ts
+++ b/scripts/sync-packages.test.ts
@@ -1,69 +1,126 @@
 import { describe, expect, test } from "bun:test";
-import { renderSyncedPackageMarkdown, syncPackages, SYNC_TARGETS } from "./sync-packages";
+import {
+	composePackageDocs,
+	createRemoteLoader,
+	DOC_FILE_ORDER,
+	renderSyncedPackageMarkdown,
+	SYNC_TARGETS,
+	syncPackages,
+	type DocFileLoader,
+} from "./sync-packages";
 
-describe("documentation sync: packages", () => {
-	test("renderSyncedPackageMarkdown() is deterministic and preserves source", () => {
+/** In-memory loader: files maps "repo/file" → content. */
+function memoryLoader(files: Record<string, string>): DocFileLoader {
+	return {
+		describeSource: (repo, file) => `mem://${repo}/docs/${file}`,
+		loadFile: async (repo, file) => files[`${repo}/${file}`] ?? null,
+	};
+}
+
+describe("documentation sync: composition", () => {
+	test("DOC_FILE_ORDER is the contract phase-2 order", () => {
+		expect(DOC_FILE_ORDER).toEqual(["index.md", "quickstart.md", "api.md", "migration.md"]);
+	});
+
+	test("composePackageDocs() concatenates existing files in contract order", async () => {
+		const loader = memoryLoader({
+			"http/index.md": "# @bunary/http\n",
+			"http/api.md": "## API\n",
+			"http/quickstart.md": "## Quickstart\n",
+		});
+		const result = await composePackageDocs("http", loader);
+		expect(result).not.toBeNull();
+		const markdown = result!.markdown;
+		expect(markdown.indexOf("# @bunary/http")).toBeLessThan(markdown.indexOf("## Quickstart"));
+		expect(markdown.indexOf("## Quickstart")).toBeLessThan(markdown.indexOf("## API"));
+		expect(result!.sources).toEqual([
+			"mem://http/docs/index.md",
+			"mem://http/docs/quickstart.md",
+			"mem://http/docs/api.md",
+		]);
+	});
+
+	test("composePackageDocs() returns null when index.md is missing", async () => {
+		const loader = memoryLoader({ "http/api.md": "## API\n" });
+		expect(await composePackageDocs("http", loader)).toBeNull();
+	});
+
+	test("renderSyncedPackageMarkdown() lists every source in the header", () => {
 		const out = renderSyncedPackageMarkdown({
 			generatorCommand: "bun run sync:packages",
-			sourceUrl: "https://example.com/docs/index.md",
+			sources: ["mem://core/docs/index.md", "mem://core/docs/api.md"],
 			sourceMarkdown: "# @bunary/core\n\nHello\n",
 		});
-
 		expect(out).toContain("AUTO-GENERATED");
-		expect(out).toContain("bun run sync:packages");
-		expect(out).toContain("https://example.com/docs/index.md");
+		expect(out).toContain("mem://core/docs/index.md");
+		expect(out).toContain("mem://core/docs/api.md");
 		expect(out).toContain("# @bunary/core");
 		expect(out.endsWith("\n")).toBe(true);
 	});
 
 	test("syncPackages() writes packages/*.md for all targets", async () => {
-		const fetchCalls: string[] = [];
 		const writes = new Map<string, string>();
+		const files: Record<string, string> = {};
+		for (const t of SYNC_TARGETS) files[`${t.repo}/index.md`] = `# @bunary/${t.repo}\n`;
 
 		await syncPackages({
 			repoRootDir: "/repo",
-			fetchText: async (url) => {
-				fetchCalls.push(url);
-				return `# ${url}\n`;
-			},
+			loader: memoryLoader(files),
 			writeFile: async (absolutePath, content) => {
 				writes.set(absolutePath, content);
 			},
 		});
 
-		// Fetch order should match target order (deterministic).
-		expect(fetchCalls).toEqual(SYNC_TARGETS.map((t) => t.sourceUrl));
-
-		// Output files should be written for every target.
 		for (const target of SYNC_TARGETS) {
 			const outPath = `/repo/packages/${target.outputFileName}`;
 			expect(writes.has(outPath)).toBe(true);
-			expect(writes.get(outPath)).toContain(`# ${target.sourceUrl}`);
+			expect(writes.get(outPath)).toContain(`# @bunary/${target.repo}`);
 		}
 	});
 
-	test("syncPackages() can skip missing sources when strict=false", async () => {
+	test("syncPackages() skips packages missing index.md when strict=false", async () => {
 		const writes = new Map<string, string>();
-
 		await syncPackages({
 			repoRootDir: "/repo",
 			strict: false,
-			targets: [
-				{
-					repo: "cli",
-					outputFileName: "cli.md",
-					sourceUrl: "https://example.com/missing.md",
-				},
-			],
-			fetchText: async () => {
-				throw new Error("404 Not Found");
-			},
+			targets: [{ repo: "cli", outputFileName: "cli.md" }],
+			loader: memoryLoader({}),
 			writeFile: async (absolutePath, content) => {
 				writes.set(absolutePath, content);
 			},
 		});
-
 		expect(writes.size).toBe(0);
 	});
-});
 
+	test("syncPackages() throws on missing index.md when strict=true", async () => {
+		expect(
+			syncPackages({
+				repoRootDir: "/repo",
+				strict: true,
+				targets: [{ repo: "cli", outputFileName: "cli.md" }],
+				loader: memoryLoader({}),
+				writeFile: async () => {},
+			}),
+		).rejects.toThrow(/cli/);
+	});
+
+	test("createRemoteLoader() returns null on 404 and content on 200", async () => {
+		const fakeFetch = (async (url: string | URL | Request) => {
+			const u = String(url);
+			if (u.endsWith("quickstart.md")) return new Response("nope", { status: 404 });
+			return new Response(`# from ${u}`, { status: 200 });
+		}) as typeof fetch;
+		const loader = createRemoteLoader(fakeFetch);
+		expect(await loader.loadFile("core", "quickstart.md")).toBeNull();
+		expect(await loader.loadFile("core", "index.md")).toContain("# from ");
+		expect(loader.describeSource("core", "index.md")).toBe(
+			"https://raw.githubusercontent.com/bunary-dev/core/main/docs/index.md",
+		);
+	});
+
+	test("createRemoteLoader() throws on non-404 errors", async () => {
+		const fakeFetch = (async () => new Response("boom", { status: 500 })) as typeof fetch;
+		const loader = createRemoteLoader(fakeFetch);
+		expect(loader.loadFile("core", "index.md")).rejects.toThrow(/500/);
+	});
+});

--- a/scripts/sync-packages.test.ts
+++ b/scripts/sync-packages.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import {
 	composePackageDocs,
+	createLocalLoader,
 	createRemoteLoader,
 	DOC_FILE_ORDER,
+	loaderFromArgv,
 	renderSyncedPackageMarkdown,
 	SYNC_TARGETS,
 	syncPackages,
@@ -122,5 +124,46 @@ describe("documentation sync: composition", () => {
 		const fakeFetch = (async () => new Response("boom", { status: 500 })) as typeof fetch;
 		const loader = createRemoteLoader(fakeFetch);
 		expect(loader.loadFile("core", "index.md")).rejects.toThrow(/500/);
+	});
+});
+
+describe("documentation sync: local mode", () => {
+	test("createLocalLoader() reads <root>/<repo>/docs/<file> and nulls ENOENT", async () => {
+		const reads: string[] = [];
+		const loader = createLocalLoader("/ws/packages", async (path) => {
+			reads.push(path);
+			if (path === "/ws/packages/core/docs/index.md") return "# @bunary/core\n";
+			const err = new Error("not found") as NodeJS.ErrnoException;
+			err.code = "ENOENT";
+			throw err;
+		});
+		expect(await loader.loadFile("core", "index.md")).toBe("# @bunary/core\n");
+		expect(await loader.loadFile("core", "quickstart.md")).toBeNull();
+		expect(reads).toContain("/ws/packages/core/docs/quickstart.md");
+		expect(loader.describeSource("core", "index.md")).toBe("/ws/packages/core/docs/index.md");
+	});
+
+	test("createLocalLoader() rethrows non-ENOENT errors", async () => {
+		const loader = createLocalLoader("/ws/packages", async () => {
+			const err = new Error("permission denied") as NodeJS.ErrnoException;
+			err.code = "EACCES";
+			throw err;
+		});
+		expect(loader.loadFile("core", "index.md")).rejects.toThrow(/permission denied/);
+	});
+
+	test("loaderFromArgv() defaults to remote", () => {
+		const loader = loaderFromArgv([], "/docs-repo");
+		expect(loader.describeSource("core", "index.md")).toStartWith("https://raw.githubusercontent.com/");
+	});
+
+	test("loaderFromArgv() with bare --local uses ../packages relative to cwd", () => {
+		const loader = loaderFromArgv(["--local"], "/ws/documentation");
+		expect(loader.describeSource("core", "index.md")).toBe("/ws/packages/core/docs/index.md");
+	});
+
+	test("loaderFromArgv() with --local <root> uses the given root", () => {
+		const loader = loaderFromArgv(["--local", "/elsewhere/pkgs"], "/ws/documentation");
+		expect(loader.describeSource("core", "index.md")).toBe("/elsewhere/pkgs/core/docs/index.md");
 	});
 });

--- a/scripts/sync-packages.ts
+++ b/scripts/sync-packages.ts
@@ -2,69 +2,128 @@
 /**
  * Sync package docs from package repos into this repo's `packages/*.md`.
  *
- * Source-of-truth: each package repo `docs/index.md`
- * Output: this repo `packages/<pkg>.md`
+ * Source-of-truth: each package repo's `docs/` directory. Per package we compose
+ * (in order): index.md (mandatory), quickstart.md, api.md, migration.md (optional).
+ *
+ * Default mode fetches from GitHub main. `--local [root]` reads from local
+ * sibling checkouts instead (root defaults to ../packages) so doc changes can
+ * be previewed before pushing.
  *
  * @example
  * ```bash
  * bun run sync:packages
+ * bun run sync:packages --local
+ * bun run sync:packages --local /path/to/packages
  * ```
  */
 
-import { mkdir, writeFile } from "fs/promises";
-import { dirname, join } from "path";
+import { mkdir, readFile, writeFile } from "fs/promises";
+import { dirname, join, resolve } from "path";
+
+/** Contract phase-2 composition order. Only index.md is mandatory. */
+export const DOC_FILE_ORDER: ReadonlyArray<string> = Object.freeze([
+	"index.md",
+	"quickstart.md",
+	"api.md",
+	"migration.md",
+]);
 
 export type SyncTarget = Readonly<{
-	/**
-	 * GitHub repository name under `bunary-dev/` (e.g. `core`, `http`).
-	 */
+	/** GitHub repository name under `bunary-dev/` (e.g. `core`, `http`). */
 	repo: string;
-	/**
-	 * Output filename under `packages/` (e.g. `core.md`).
-	 */
+	/** Output filename under `packages/` (e.g. `core.md`). */
 	outputFileName: string;
-	/**
-	 * Raw URL to fetch markdown content from.
-	 */
-	sourceUrl: string;
 }>;
 
 /**
- * Deterministic list of package docs we sync (phase 1).
- *
- * Extending this list is the only change needed to sync another package's `docs/index.md`.
+ * Deterministic list of package docs we sync.
+ * Extending this list is the only change needed to sync another package.
  */
 export const SYNC_TARGETS: ReadonlyArray<SyncTarget> = Object.freeze([
-	{
-		repo: "core",
-		outputFileName: "core.md",
-		sourceUrl: "https://raw.githubusercontent.com/bunary-dev/core/main/docs/index.md",
-	},
-	{
-		repo: "http",
-		outputFileName: "http.md",
-		sourceUrl: "https://raw.githubusercontent.com/bunary-dev/http/main/docs/index.md",
-	},
-	{
-		repo: "auth",
-		outputFileName: "auth.md",
-		sourceUrl: "https://raw.githubusercontent.com/bunary-dev/auth/main/docs/index.md",
-	},
-	{
-		repo: "orm",
-		outputFileName: "orm.md",
-		sourceUrl: "https://raw.githubusercontent.com/bunary-dev/orm/main/docs/index.md",
-	},
-	{
-		repo: "cli",
-		outputFileName: "cli.md",
-		sourceUrl: "https://raw.githubusercontent.com/bunary-dev/cli/main/docs/index.md",
-	},
+	{ repo: "core", outputFileName: "core.md" },
+	{ repo: "http", outputFileName: "http.md" },
+	{ repo: "auth", outputFileName: "auth.md" },
+	{ repo: "orm", outputFileName: "orm.md" },
+	{ repo: "cli", outputFileName: "cli.md" },
 ]);
+
+/**
+ * Loads package doc files from some source (GitHub raw, local checkout, memory).
+ * `loadFile` resolves `null` when the file does not exist at the source.
+ */
+export type DocFileLoader = Readonly<{
+	describeSource: (repo: string, file: string) => string;
+	loadFile: (repo: string, file: string) => Promise<string | null>;
+}>;
+
+/**
+ * Loader that fetches from GitHub raw (main branch). 404 → null; other
+ * non-OK responses throw.
+ */
+export function createRemoteLoader(fetchImpl: typeof fetch = fetch): DocFileLoader {
+	const urlFor = (repo: string, file: string) =>
+		`https://raw.githubusercontent.com/bunary-dev/${repo}/main/docs/${file}`;
+	return {
+		describeSource: urlFor,
+		loadFile: async (repo, file) => {
+			const url = urlFor(repo, file);
+			const res = await fetchImpl(url);
+			if (res.status === 404) return null;
+			if (!res.ok) {
+				throw new Error(`Failed to fetch "${url}" (${res.status} ${res.statusText})`);
+			}
+			return await res.text();
+		},
+	};
+}
+
+/**
+ * Loader that reads from local package checkouts: `<root>/<repo>/docs/<file>`.
+ * Missing file (ENOENT) → null; other filesystem errors throw.
+ */
+export function createLocalLoader(
+	packagesRootDir: string,
+	readFileImpl: (path: string) => Promise<string> = (path) => readFile(path, "utf-8"),
+): DocFileLoader {
+	const pathFor = (repo: string, file: string) => join(packagesRootDir, repo, "docs", file);
+	return {
+		describeSource: pathFor,
+		loadFile: async (repo, file) => {
+			try {
+				return await readFileImpl(pathFor(repo, file));
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+				throw error;
+			}
+		},
+	};
+}
+
+/**
+ * Compose one package page from its doc files in DOC_FILE_ORDER.
+ * Returns null when the mandatory index.md is missing.
+ */
+export async function composePackageDocs(
+	repo: string,
+	loader: DocFileLoader,
+): Promise<{ sources: string[]; markdown: string } | null> {
+	const parts: string[] = [];
+	const sources: string[] = [];
+	for (const file of DOC_FILE_ORDER) {
+		const content = await loader.loadFile(repo, file);
+		if (content === null) {
+			if (file === "index.md") return null;
+			continue;
+		}
+		parts.push(normalizeNewlines(content).trim());
+		sources.push(loader.describeSource(repo, file));
+	}
+	return { sources, markdown: `${parts.join("\n\n")}\n` };
+}
 
 export type RenderSyncedPackageMarkdownArgs = Readonly<{
 	generatorCommand: string;
-	sourceUrl: string;
+	sources: ReadonlyArray<string>;
 	sourceMarkdown: string;
 }>;
 
@@ -78,7 +137,7 @@ export function renderSyncedPackageMarkdown(args: RenderSyncedPackageMarkdownArg
 		"<!--",
 		"  AUTO-GENERATED FILE — DO NOT EDIT DIRECTLY.",
 		`  Generated by: ${args.generatorCommand}`,
-		`  Source: ${args.sourceUrl}`,
+		...args.sources.map((source) => `  Source: ${source}`),
 		"-->",
 		"",
 	].join("\n");
@@ -91,58 +150,34 @@ function normalizeNewlines(input: string): string {
 }
 
 export type SyncPackagesOptions = Readonly<{
-	/**
-	 * Absolute repo root directory. Defaults to `process.cwd()`.
-	 */
+	/** Absolute repo root directory. Defaults to `process.cwd()`. */
 	repoRootDir?: string;
-	/**
-	 * Fetch a URL as text. Defaults to `fetch(url).text()`.
-	 */
-	fetchText?: (url: string) => Promise<string>;
-	/**
-	 * Write a file (absolute path). Defaults to `fs/promises.writeFile`.
-	 */
+	/** Doc file loader. Defaults to the remote (GitHub raw) loader. */
+	loader?: DocFileLoader;
+	/** Write a file (absolute path). Defaults to `fs/promises.writeFile`. */
 	writeFile?: (absolutePath: string, content: string) => Promise<void>;
-	/**
-	 * Ensure a directory exists (absolute path). If omitted, directories are created
-	 * only when using the default writer.
-	 */
+	/** Ensure a directory exists (absolute path). */
 	mkdirp?: (absoluteDir: string) => Promise<void>;
-	/**
-	 * Which targets to sync. Defaults to `SYNC_TARGETS`.
-	 */
+	/** Which targets to sync. Defaults to `SYNC_TARGETS`. */
 	targets?: ReadonlyArray<SyncTarget>;
 	/**
-	 * If true, throw on the first fetch/write error. If false, log and continue.
-	 * Defaults to false (CI drift-check can enforce strictness later).
+	 * If true, throw when a package's mandatory index.md is missing or a
+	 * source errors. If false, log and continue. Defaults to false.
 	 */
 	strict?: boolean;
 }>;
 
-/**
- * Sync all package docs into `packages/`.
- */
+/** Sync all package docs into `packages/`. */
 export async function syncPackages(options: SyncPackagesOptions = {}): Promise<void> {
 	const repoRootDir = options.repoRootDir ?? process.cwd();
 	const targets = options.targets ?? SYNC_TARGETS;
 	const strict = options.strict ?? false;
-
-	const fetchText =
-		options.fetchText ??
-		(async (url: string) => {
-			const res = await fetch(url);
-			if (!res.ok) {
-				throw new Error(`Failed to fetch "${url}" (${res.status} ${res.statusText})`);
-			}
-			return await res.text();
-		});
+	const loader = options.loader ?? createRemoteLoader();
 
 	const defaultMkdirp = async (absoluteDir: string) => {
 		await mkdir(absoluteDir, { recursive: true });
 	};
-
 	const mkdirp = options.mkdirp ?? (options.writeFile ? undefined : defaultMkdirp);
-
 	const writer =
 		options.writeFile ??
 		(async (absolutePath: string, content: string) => {
@@ -150,36 +185,49 @@ export async function syncPackages(options: SyncPackagesOptions = {}): Promise<v
 		});
 
 	for (const target of targets) {
-		let sourceMarkdown: string;
+		let composed: { sources: string[]; markdown: string } | null;
 		try {
-			sourceMarkdown = await fetchText(target.sourceUrl);
+			composed = await composePackageDocs(target.repo, loader);
 		} catch (error) {
 			if (strict) throw error;
 			console.warn(
-				`⚠️  Skipping "${target.repo}" (failed to fetch ${target.sourceUrl}): ${
+				`⚠️  Skipping "${target.repo}" (source error): ${
 					error instanceof Error ? error.message : String(error)
 				}`,
 			);
 			continue;
 		}
 
+		if (composed === null) {
+			const message = `Package "${target.repo}" is missing mandatory docs/index.md (${loader.describeSource(target.repo, "index.md")})`;
+			if (strict) throw new Error(message);
+			console.warn(`⚠️  Skipping "${target.repo}": ${message}`);
+			continue;
+		}
+
 		const outputMarkdown = renderSyncedPackageMarkdown({
 			generatorCommand: "bun run sync:packages",
-			sourceUrl: target.sourceUrl,
-			sourceMarkdown,
+			sources: composed.sources,
+			sourceMarkdown: composed.markdown,
 		});
 
 		const outputPath = join(repoRootDir, "packages", target.outputFileName);
-
 		if (mkdirp) {
 			await mkdirp(dirname(outputPath));
 		}
-
 		await writer(outputPath, outputMarkdown);
 	}
 }
 
-if (import.meta.main) {
-	await syncPackages();
+/** Parse CLI args: `--local [root]` selects the local loader. */
+export function loaderFromArgv(argv: ReadonlyArray<string>, cwd: string): DocFileLoader {
+	const localIndex = argv.indexOf("--local");
+	if (localIndex === -1) return createRemoteLoader();
+	const next = argv[localIndex + 1];
+	const root = next && !next.startsWith("--") ? next : join(cwd, "..", "packages");
+	return createLocalLoader(resolve(cwd, root));
 }
 
+if (import.meta.main) {
+	await syncPackages({ loader: loaderFromArgv(process.argv.slice(2), process.cwd()) });
+}

--- a/scripts/sync-site.test.ts
+++ b/scripts/sync-site.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { generateIndexContent, parseFrontmatter, type ProcessedFile } from "./sync-site";
+
+describe("sync-site: frontmatter", () => {
+	test("parses title, description, and order", () => {
+		const { metadata, body } = parseFrontmatter(
+			"---\ntitle: Routing\ndescription: How routes work\norder: 3\n---\n# Routing\n\nBody\n",
+		);
+		expect(metadata.title).toBe("Routing");
+		expect(metadata.description).toBe("How routes work");
+		expect(metadata.order).toBe(3);
+		expect(body).toContain("# Routing");
+	});
+
+	test("no frontmatter keeps heading-derived behaviour and undefined order", () => {
+		const { metadata } = parseFrontmatter("# My Title\n\nFirst paragraph here.\n\n## More\n");
+		expect(metadata.title).toBe("My Title");
+		expect(metadata.description).toBe("First paragraph here.");
+		expect(metadata.order).toBeUndefined();
+	});
+
+	test("non-numeric order is ignored", () => {
+		const { metadata } = parseFrontmatter("---\ntitle: X\norder: soon\n---\nBody\n");
+		expect(metadata.order).toBeUndefined();
+	});
+});
+
+describe("sync-site: index generation", () => {
+	const file = (over: Partial<ProcessedFile>): ProcessedFile => ({
+		componentName: "X",
+		exportName: "X",
+		filePath: "/out/X.tsx",
+		isPackage: false,
+		...over,
+	});
+
+	test("guides sort by order first, then name; unordered files sink to the end", () => {
+		const content = generateIndexContent(
+			[
+				file({ componentName: "Zebra", exportName: "Zebra", filePath: "/out/Zebra.tsx", order: 1 }),
+				file({ componentName: "Alpha", exportName: "Alpha", filePath: "/out/Alpha.tsx" }),
+				file({ componentName: "Mid", exportName: "Mid", filePath: "/out/Mid.tsx", order: 2 }),
+			],
+			"/out",
+		);
+		const zebra = content.indexOf("Zebra");
+		const mid = content.indexOf("Mid");
+		const alpha = content.indexOf("Alpha");
+		expect(zebra).toBeLessThan(mid);
+		expect(mid).toBeLessThan(alpha);
+	});
+
+	test("packages are exported after guides", () => {
+		const content = generateIndexContent(
+			[
+				file({ componentName: "CorePackage", exportName: "CorePackage", filePath: "/out/packages/Core.tsx", isPackage: true }),
+				file({ componentName: "Guide", exportName: "Guide", filePath: "/out/Guide.tsx" }),
+			],
+			"/out",
+		);
+		expect(content.indexOf("Guide")).toBeLessThan(content.indexOf("CorePackage"));
+		expect(content).toContain('from "./packages/Core.js"');
+		expect(content).toContain('export { default as DocsLayout } from "./DocsLayout.js";');
+	});
+});

--- a/scripts/sync-site.ts
+++ b/scripts/sync-site.ts
@@ -25,12 +25,13 @@ const DOCS_DIR = process.cwd();
 const OUTPUT_DIR =
 	process.env.DOCS_SITE_OUTPUT ?? join(DOCS_DIR, "..", "site", "src", "pages", "docs");
 
-interface DocMetadata {
+export interface DocMetadata {
 	title: string;
 	description: string;
+	order?: number;
 }
 
-function parseFrontmatter(content: string): { metadata: DocMetadata; body: string } {
+export function parseFrontmatter(content: string): { metadata: DocMetadata; body: string } {
 	const frontmatterRegex = /^---\n([\s\S]*?)\n---\n([\s\S]*)$/;
 	const match = content.match(frontmatterRegex);
 
@@ -53,6 +54,10 @@ function parseFrontmatter(content: string): { metadata: DocMetadata; body: strin
 			const clean = value.replace(/^["']|["']$/g, "");
 			if (key === "title") metadata.title = clean;
 			if (key === "description") metadata.description = clean;
+			if (key === "order") {
+				const parsed = Number(clean);
+				if (Number.isFinite(parsed)) metadata.order = parsed;
+			}
 		}
 	}
 	return { metadata, body };
@@ -116,11 +121,12 @@ export default ${componentName};
 `;
 }
 
-interface ProcessedFile {
+export interface ProcessedFile {
 	componentName: string;
 	exportName: string;
 	filePath: string;
 	isPackage: boolean;
+	order?: number;
 }
 
 const processedFiles: ProcessedFile[] = [];
@@ -190,7 +196,7 @@ async function processMarkdownFile(filePath: string, relativePath: string): Prom
 
 	const component = await markdownToReactComponent(metadata, body, componentName);
 	await writeFile(outputPath, component, "utf-8");
-	processedFiles.push({ componentName, exportName, filePath: outputPath, isPackage });
+	processedFiles.push({ componentName, exportName, filePath: outputPath, isPackage, order: metadata.order });
 	console.log(`✓ Generated ${outputPath}`);
 }
 
@@ -207,12 +213,19 @@ async function processDirectory(dir: string, relativePath: string = ""): Promise
 	}
 }
 
-async function generateIndexFile(): Promise<void> {
-	const guides = processedFiles.filter((f) => !f.isPackage).sort((a, b) => a.componentName.localeCompare(b.componentName));
-	const packages = processedFiles.filter((f) => f.isPackage).sort((a, b) => a.componentName.localeCompare(b.componentName));
+function byOrderThenName(a: ProcessedFile, b: ProcessedFile): number {
+	const ao = a.order ?? Number.MAX_SAFE_INTEGER;
+	const bo = b.order ?? Number.MAX_SAFE_INTEGER;
+	if (ao !== bo) return ao - bo;
+	return a.componentName.localeCompare(b.componentName);
+}
+
+export function generateIndexContent(files: ProcessedFile[], outputDir: string): string {
+	const guides = files.filter((f) => !f.isPackage).sort(byOrderThenName);
+	const packages = files.filter((f) => f.isPackage).sort(byOrderThenName);
 	const exports: string[] = [];
 	for (const file of guides) {
-		const rel = relative(OUTPUT_DIR, file.filePath).replace(/\\/g, "/");
+		const rel = relative(outputDir, file.filePath).replace(/\\/g, "/");
 		const importPath = rel.replace(/\.tsx$/, ".js");
 		exports.push(`export { default as ${file.exportName} } from "./${importPath}";`);
 	}
@@ -222,7 +235,7 @@ async function generateIndexFile(): Promise<void> {
 			exports.push(`export { default as ${file.exportName} } from "./packages/${basename(file.filePath, ".tsx")}.js";`);
 		}
 	}
-	const indexContent = `/**
+	return `/**
  * Documentation pages - auto-generated. Do not edit directly.
  */
 
@@ -230,7 +243,10 @@ export { default as DocsLayout } from "./DocsLayout.js";
 
 ${exports.join("\n")}
 `;
-	await writeFile(join(OUTPUT_DIR, "index.ts"), indexContent, "utf-8");
+}
+
+async function generateIndexFile(): Promise<void> {
+	await writeFile(join(OUTPUT_DIR, "index.ts"), generateIndexContent(processedFiles, OUTPUT_DIR), "utf-8");
 	console.log("✓ Generated index.ts");
 }
 
@@ -265,7 +281,9 @@ async function build(): Promise<void> {
 	console.log(`\n✅ Site docs build complete! (${processedFiles.length} files)`);
 }
 
-build().catch((err) => {
-	console.error("❌ Build failed:", err);
-	process.exit(1);
-});
+if (import.meta.main) {
+	build().catch((err) => {
+		console.error("❌ Build failed:", err);
+		process.exit(1);
+	});
+}


### PR DESCRIPTION
Closes #45.

- Multi-file package-doc composition (contract phase 2): index + quickstart + api + migration
- `--local` sync mode reading sibling package checkouts for preview (remote fetch stays the default; CI drift check unchanged)
- Frontmatter standard (title/description/order) driving site export order; heading-derived fallback preserved
- sync-site refactored into testable exported functions with an import.meta.main guard
- bunary-docs Claude skill (.claude/skills/) capturing the workflow
- Process docs (README, PACKAGE_DOCS_CONTRACT, PUBLISH_WORKFLOW) updated; includes one remote-drift refresh of packages/*.md

Spec: docs/superpowers/specs/2026-07-06-docs-process-v2-design.md
Plan: docs/superpowers/plans/2026-07-06-docs-process-v2.md
Tests: 19 pass, 0 fail (bun test, 2 files, 48 assertions); biome clean.

Deferred follow-ups from review (all cosmetic): output-cleaning test for sync-site; one index-only phrase in PACKAGE_DOCS_CONTRACT.md Ownership section; index.md-only example in PUBLISH_WORKFLOW.md CI paragraph.