### PR TITLE
chore: cosmetic follow-ups from #46 review

### DIFF
--- a/PACKAGE_DOCS_CONTRACT.md
+++ b/PACKAGE_DOCS_CONTRACT.md
@@ -95,6 +95,6 @@ If README and `docs/index.md` both list "all commands" or the same examples, fix
 ## Ownership
 
 - `guides/**` is authored and maintained in this repo.
-- `packages/*.md` is synced output from package `docs/index.md`; do not hand-edit except when fixing sync bugs.
+- `packages/*.md` is synced output composed from each package's `docs/` files (`index.md`, plus `quickstart.md`, `api.md`, `migration.md` when present); do not hand-edit except when fixing sync bugs.
 - Canonical package docs content lives in each package repo under `docs/`.
 

--- a/PUBLISH_WORKFLOW.md
+++ b/PUBLISH_WORKFLOW.md
@@ -10,6 +10,6 @@ To preview package-doc changes before pushing, run `bun run scripts/sync-package
 
 Who runs it: whoever is doing the release or the follow-up doc pass. There is no automated trigger yet. A practical rule: when you cut a package release or merge a feature that changed docs, run sync and open a PR in this repo with the updated `packages/*.md`, or add “run sync and commit” to the release checklist for that package.
 
-CI: PRs in this repo run a drift check. If `bun run sync:packages` would produce changes but the PR didn’t include them, CI fails. So if a package’s `docs/index.md` changed and you didn’t sync, the next person to touch this repo may hit that failure; then they run sync and commit the result.
+CI: PRs in this repo run a drift check. If `bun run sync:packages` would produce changes but the PR didn’t include them, CI fails. So if any of a package’s composed doc files (`docs/index.md`, `quickstart.md`, `api.md`, `migration.md`) changed and you didn’t sync, the next person to touch this repo may hit that failure; then they run sync and commit the result.
 
 Summary: change package docs in the package repo; run `bun run sync:packages` here and commit updated `packages/*.md` so Documentation stays in sync. No version bump in this repo for doc-only syncs.

--- a/scripts/sync-packages.test.ts
+++ b/scripts/sync-packages.test.ts
@@ -125,6 +125,34 @@ describe("documentation sync: composition", () => {
 		const loader = createRemoteLoader(fakeFetch);
 		expect(loader.loadFile("core", "index.md")).rejects.toThrow(/500/);
 	});
+
+	test("composePackageDocs() normalizes CRLF and irregular whitespace deterministically", async () => {
+		const loader = memoryLoader({
+			"core/index.md": "# @bunary/core\r\n\r\nIntro line\r\n\r\n\r\n",
+			"core/quickstart.md": "\n\n## Quickstart\r\nSteps here\n\n\n",
+		});
+		const result = await composePackageDocs("core", loader);
+		expect(result).not.toBeNull();
+		const markdown = result!.markdown;
+		// CRLF collapsed to LF everywhere.
+		expect(markdown).not.toContain("\r");
+		// Parts joined by exactly one blank line despite ragged source edges.
+		expect(markdown).toBe("# @bunary/core\n\nIntro line\n\n## Quickstart\nSteps here\n");
+		// Same inputs → same output (deterministic).
+		const again = await composePackageDocs("core", loader);
+		expect(again!.markdown).toBe(markdown);
+	});
+
+	test("renderSyncedPackageMarkdown() normalizes CRLF sources to LF with single trailing newline", () => {
+		const out = renderSyncedPackageMarkdown({
+			generatorCommand: "bun run sync:packages",
+			sources: ["mem://core/docs/index.md"],
+			sourceMarkdown: "# @bunary/core\r\n\r\nBody\r\n\r\n",
+		});
+		expect(out).not.toContain("\r");
+		expect(out.endsWith("Body\n")).toBe(true);
+		expect(out.endsWith("Body\n\n")).toBe(false);
+	});
 });
 
 describe("documentation sync: local mode", () => {


### PR DESCRIPTION
Closes #47.

- Two characterization tests: composePackageDocs CRLF/irregular-whitespace normalization + renderSyncedPackageMarkdown CRLF handling (21 tests total now)
- PACKAGE_DOCS_CONTRACT.md Ownership: packages/*.md described as composed from all docs/ files
- PUBLISH_WORKFLOW.md CI paragraph: drift example broadened beyond index.md

Tests: 21 pass, 0 fail; biome clean.